### PR TITLE
Improve password and account settings

### DIFF
--- a/Catacombs.Tests/SecurityIntegrationTests.cs
+++ b/Catacombs.Tests/SecurityIntegrationTests.cs
@@ -157,6 +157,83 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task ChangingPasswordValidatesTheRequestAndSignsOut()
+    {
+        const string newPassword =
+            "A new Catacombs password! 2026";
+        var email = NewEmail("change-password");
+
+        var registerResponse = await RegisterAsync(
+            _client,
+            "Password Tester",
+            email);
+        Assert.Equal(HttpStatusCode.Created, registerResponse.StatusCode);
+
+        var loginResponse = await LoginAsync(
+            _client,
+            email,
+            TestPassword);
+        Assert.Equal(HttpStatusCode.OK, loginResponse.StatusCode);
+
+        var wrongCurrentPassword = await ChangePasswordAsync(
+            _client,
+            "Not the current password",
+            newPassword,
+            newPassword);
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            wrongCurrentPassword.StatusCode);
+
+        var mismatchedPasswords = await ChangePasswordAsync(
+            _client,
+            TestPassword,
+            newPassword,
+            "A different confirmation password");
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            mismatchedPasswords.StatusCode);
+
+        var unchangedPassword = await ChangePasswordAsync(
+            _client,
+            TestPassword,
+            TestPassword,
+            TestPassword);
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            unchangedPassword.StatusCode);
+
+        var changedPassword = await ChangePasswordAsync(
+            _client,
+            TestPassword,
+            newPassword,
+            newPassword);
+        Assert.Equal(
+            HttpStatusCode.NoContent,
+            changedPassword.StatusCode);
+
+        var signedOutUser = await _client.GetAsync("/api/auth/me");
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            signedOutUser.StatusCode);
+
+        var oldPasswordLogin = await LoginAsync(
+            _client,
+            email,
+            TestPassword);
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            oldPasswordLogin.StatusCode);
+
+        var newPasswordLogin = await LoginAsync(
+            _client,
+            email,
+            newPassword);
+        Assert.Equal(
+            HttpStatusCode.OK,
+            newPasswordLogin.StatusCode);
+    }
+
+    [Fact]
     public async Task MovieChangesRequireAuthenticationAndAnAntiforgeryToken()
     {
         var anonymousResponse = await _client.GetAsync("/api/movies");
@@ -401,6 +478,24 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
             {
                 email,
                 password
+            });
+    }
+
+    private static async Task<HttpResponseMessage> ChangePasswordAsync(
+        HttpClient client,
+        string currentPassword,
+        string newPassword,
+        string confirmNewPassword)
+    {
+        return await SendWithAntiforgeryAsync(
+            client,
+            HttpMethod.Post,
+            "/api/auth/change-password",
+            new
+            {
+                currentPassword,
+                newPassword,
+                confirmNewPassword
             });
     }
 

--- a/Catacombs.Tests/SecurityIntegrationTests.cs
+++ b/Catacombs.Tests/SecurityIntegrationTests.cs
@@ -90,6 +90,30 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
     }
 
     [Fact]
+    public async Task RegistrationRequiresAtLeastEightPasswordCharacters()
+    {
+        var shortPasswordResponse = await RegisterAsync(
+            _client,
+            "Short Password",
+            NewEmail("short-password"),
+            "Seven77");
+
+        Assert.Equal(
+            HttpStatusCode.BadRequest,
+            shortPasswordResponse.StatusCode);
+
+        var minimumPasswordResponse = await RegisterAsync(
+            _client,
+            "Minimum Password",
+            NewEmail("minimum-password"),
+            "Eight888");
+
+        Assert.Equal(
+            HttpStatusCode.Created,
+            minimumPasswordResponse.StatusCode);
+    }
+
+    [Fact]
     public async Task LoginRejectsTheWrongPasswordAndMaintainsASession()
     {
         var email = NewEmail("session");
@@ -349,7 +373,8 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
     private static async Task<HttpResponseMessage> RegisterAsync(
         HttpClient client,
         string username,
-        string email)
+        string email,
+        string password = TestPassword)
     {
         return await SendWithAntiforgeryAsync(
             client,
@@ -359,7 +384,7 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
             {
                 username,
                 email,
-                password = TestPassword
+                password
             });
     }
 

--- a/Catacombs/Contracts/Authentication/ChangePasswordRequest.cs
+++ b/Catacombs/Contracts/Authentication/ChangePasswordRequest.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Catacombs.Contracts.Authentication
+{
+    public sealed class ChangePasswordRequest
+    {
+        [Required]
+        [StringLength(128, MinimumLength = 1)]
+        public string CurrentPassword { get; set; }
+
+        [Required]
+        [StringLength(128, MinimumLength = 8)]
+        public string NewPassword { get; set; }
+
+        [Required]
+        [StringLength(128)]
+        [Compare(
+            nameof(NewPassword),
+            ErrorMessage = "The new passwords must match.")]
+        public string ConfirmNewPassword { get; set; }
+    }
+}

--- a/Catacombs/Contracts/Authentication/RegisterRequest.cs
+++ b/Catacombs/Contracts/Authentication/RegisterRequest.cs
@@ -14,7 +14,7 @@ namespace Catacombs.Contracts.Authentication
         public string Email { get; set; }
 
         [Required]
-        [StringLength(128, MinimumLength = 15)]
+        [StringLength(128, MinimumLength = 8)]
         public string Password { get; set; }
     }
 }

--- a/Catacombs/Controllers/AuthController.cs
+++ b/Catacombs/Controllers/AuthController.cs
@@ -202,6 +202,77 @@ namespace Catacombs.Controllers
         }
 
         [Authorize]
+        [HttpPost("change-password")]
+        [ValidateAntiForgeryToken]
+        [EnableRateLimiting("PasswordChange")]
+        [ProducesResponseType(StatusCodes.Status204NoContent)]
+        [ProducesResponseType(StatusCodes.Status400BadRequest)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        [ProducesResponseType(StatusCodes.Status429TooManyRequests)]
+        public async Task<IActionResult> ChangePassword(
+            ChangePasswordRequest request)
+        {
+            var userIdValue = User.FindFirstValue(
+                ClaimTypes.NameIdentifier);
+
+            if (!int.TryParse(
+                userIdValue,
+                NumberStyles.None,
+                CultureInfo.InvariantCulture,
+                out var userId))
+            {
+                await HttpContext.SignOutAsync(
+                    CookieAuthenticationDefaults.AuthenticationScheme);
+                return Unauthorized();
+            }
+
+            var user = _usersRepository.GetById(userId);
+            if (user == null)
+            {
+                await HttpContext.SignOutAsync(
+                    CookieAuthenticationDefaults.AuthenticationScheme);
+                return Unauthorized();
+            }
+
+            var verificationResult = _passwordHasher.VerifyHashedPassword(
+                user,
+                user.passwordHash,
+                request.CurrentPassword);
+
+            if (verificationResult == PasswordVerificationResult.Failed)
+            {
+                return BadRequest(new ProblemDetails
+                {
+                    Status = StatusCodes.Status400BadRequest,
+                    Title = "The current password is incorrect."
+                });
+            }
+
+            if (string.Equals(
+                request.CurrentPassword,
+                request.NewPassword,
+                StringComparison.Ordinal))
+            {
+                ModelState.AddModelError(
+                    nameof(request.NewPassword),
+                    "The new password must be different from the current password.");
+                return ValidationProblem(ModelState);
+            }
+
+            user.passwordHash = _passwordHasher.HashPassword(
+                user,
+                request.NewPassword);
+            _usersRepository.UpdatePasswordHash(
+                user.id,
+                user.passwordHash);
+
+            await HttpContext.SignOutAsync(
+                CookieAuthenticationDefaults.AuthenticationScheme);
+
+            return NoContent();
+        }
+
+        [Authorize]
         [HttpPost("logout")]
         [ValidateAntiForgeryToken]
         [ProducesResponseType(StatusCodes.Status204NoContent)]

--- a/Catacombs/Startup.cs
+++ b/Catacombs/Startup.cs
@@ -31,6 +31,8 @@ namespace Catacombs
         private const string DevelopmentClientCorsPolicy =
             "DevelopmentClient";
         private const string LoginRateLimitPolicy = "Login";
+        private const string PasswordChangeRateLimitPolicy =
+            "PasswordChange";
 
         public Startup(IConfiguration configuration)
         {
@@ -122,6 +124,18 @@ namespace Catacombs
                     StatusCodes.Status429TooManyRequests;
                 options.AddPolicy(
                     LoginRateLimitPolicy,
+                    context => RateLimitPartition.GetFixedWindowLimiter(
+                        context.Connection.RemoteIpAddress?.ToString()
+                            ?? "unknown",
+                        _ => new FixedWindowRateLimiterOptions
+                        {
+                            AutoReplenishment = true,
+                            PermitLimit = 5,
+                            QueueLimit = 0,
+                            Window = TimeSpan.FromMinutes(1)
+                        }));
+                options.AddPolicy(
+                    PasswordChangeRateLimitPolicy,
                     context => RateLimitPartition.GetFixedWindowLimiter(
                         context.Connection.RemoteIpAddress?.ToString()
                             ?? "unknown",

--- a/Catacombs/client/src/components/ApplicationViews.js
+++ b/Catacombs/client/src/components/ApplicationViews.js
@@ -4,6 +4,7 @@ import { Spinner } from "reactstrap";
 import { UserContext } from "./Repositories/UserProvider"
 import Login from "./auth/Login";
 import Register from "./auth/Register";
+import ChangePassword from "./auth/ChangePassword";
 import { TopRatedMovieList } from "./Movies/TopRated/TopRatedMovieList";
 import { PopularMovieList } from "./Movies/Popular/PopularMovieList";
 import { HiddenGemsList } from "./Movies/HiddenGemsList";
@@ -67,6 +68,10 @@ export default function ApplicationViews() {
             <Route path="/movies/seen" element={<SeenMoviesList />} />
             <Route path="/movies/liked" element={<LikedMoviesList />} />
             <Route path="/movies/disliked" element={<DislikedMoviesList />} />
+            <Route
+              path="/account/password"
+              element={<ChangePassword />}
+            />
             <Route path="/login" element={<Navigate to="/" replace />} />
             <Route path="/register" element={<Navigate to="/" replace />} />
             <Route path="*" element={<Navigate to="/" replace />} />

--- a/Catacombs/client/src/components/Header.css
+++ b/Catacombs/client/src/components/Header.css
@@ -115,7 +115,7 @@
     background-color: rgba(230, 30, 77, 0.22);
 }
 
-.header-username {
+.catacombs-navbar .header-account-toggle.nav-link {
     padding: 0.45rem 0.7rem;
     color: #f8f9fa;
     background-color: rgba(255, 255, 255, 0.07);
@@ -125,14 +125,28 @@
     font-weight: 650;
 }
 
-.header-logout-button {
-    width: 100%;
-    background: transparent;
-    border: 0;
-    text-align: left;
+.catacombs-navbar .header-account-toggle.nav-link:hover,
+.catacombs-navbar .header-account-toggle.nav-link:focus-visible,
+.catacombs-navbar .header-account-toggle.nav-link.active {
+    color: #ffffff;
+    background-color: rgba(230, 30, 77, 0.2);
+    border-color: rgba(255, 113, 143, 0.45);
 }
 
-.header-logout-button:disabled {
+.header-account-menu .dropdown-divider {
+    border-top-color: rgba(255, 255, 255, 0.12);
+}
+
+.catacombs-navbar .header-logout-item.dropdown-item {
+    color: #ff718f;
+}
+
+.catacombs-navbar .header-logout-item.dropdown-item:hover,
+.catacombs-navbar .header-logout-item.dropdown-item:focus {
+    color: #ffffff;
+}
+
+.header-logout-item:disabled {
     color: #858c93;
     cursor: wait;
 }
@@ -171,8 +185,18 @@
         box-shadow: none;
     }
 
-    .header-username {
+    .header-account-dropdown {
         align-self: flex-start;
-        margin-bottom: 0.25rem;
+        width: 100%;
+    }
+
+    .catacombs-navbar .header-account-toggle.nav-link {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+    }
+
+    .header-account-menu {
+        width: 100%;
     }
 }

--- a/Catacombs/client/src/components/Header.js
+++ b/Catacombs/client/src/components/Header.js
@@ -218,6 +218,15 @@ export default function Header() {
                   {userProfile.username}
                 </NavbarText>
                 <NavItem>
+                  <NavLink
+                    tag={RRNavLink}
+                    to="/account/password"
+                    onClick={closeMenu}
+                  >
+                    Change password
+                  </NavLink>
+                </NavItem>
+                <NavItem>
                   <button
                     type="button"
                     className="nav-link header-logout-button"

--- a/Catacombs/client/src/components/Header.js
+++ b/Catacombs/client/src/components/Header.js
@@ -15,8 +15,7 @@ import {
   UncontrolledDropdown,
   DropdownToggle,
   DropdownMenu,
-  DropdownItem,
-  NavbarText
+  DropdownItem
 } from 'reactstrap';
 import { UserContext } from './Repositories/UserProvider';
 import icon from './Movies/images/icon.png'
@@ -213,32 +212,46 @@ export default function Header() {
 
           <Nav className="catacombs-account-nav" navbar>
             {isLoggedIn ? (
-              <>
-                <NavbarText className="header-username">
+              <UncontrolledDropdown
+                nav
+                inNavbar
+                className="header-account-dropdown"
+              >
+                <DropdownToggle
+                  nav
+                  caret
+                  className={
+                    location.pathname.startsWith("/account/")
+                      ? "header-account-toggle active"
+                      : "header-account-toggle"
+                  }
+                >
                   {userProfile.username}
-                </NavbarText>
-                <NavItem>
-                  <NavLink
+                </DropdownToggle>
+                <DropdownMenu
+                  dark
+                  end
+                  className="header-account-menu"
+                >
+                  <DropdownItem
                     tag={RRNavLink}
                     to="/account/password"
                     onClick={closeMenu}
                   >
                     Change password
-                  </NavLink>
-                </NavItem>
-                <NavItem>
-                  <button
-                    type="button"
-                    className="nav-link header-logout-button"
+                  </DropdownItem>
+                  <DropdownItem divider />
+                  <DropdownItem
+                    className="header-logout-item"
                     disabled={isLoggingOut}
                     onClick={logoutClick}
                   >
                     {isLoggingOut
                       ? "Logging out..."
                       : "Log out"}
-                  </button>
-                </NavItem>
-              </>
+                  </DropdownItem>
+                </DropdownMenu>
+              </UncontrolledDropdown>
             ) : (
               <>
                 <NavItem>

--- a/Catacombs/client/src/components/Repositories/UserProvider.js
+++ b/Catacombs/client/src/components/Repositories/UserProvider.js
@@ -150,9 +150,36 @@ export function UserProvider({ children }) {
     return response.json();
   };
 
+  const changePassword = async (passwords) => {
+    const antiforgeryToken = await getAntiforgeryToken();
+    const response = await fetch(`${apiUrl}/api/auth/change-password`, {
+      method: "POST",
+      credentials: "include",
+      headers: {
+        "Content-Type": "application/json",
+        "X-XSRF-TOKEN": antiforgeryToken,
+      },
+      body: JSON.stringify(passwords),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        clearUserProfile();
+      }
+
+      const fallbackMessage = response.status === 429
+        ? "Too many password attempts. Please wait a minute and try again."
+        : "Unable to change the password.";
+      throw new Error(await getErrorMessage(response, fallbackMessage));
+    }
+
+    clearUserProfile();
+  };
+
   return (
     <UserContext.Provider
       value={{
+        changePassword,
         isLoadingUser,
         isLoggedIn,
         login,

--- a/Catacombs/client/src/components/auth/Auth.css
+++ b/Catacombs/client/src/components/auth/Auth.css
@@ -102,6 +102,49 @@
   opacity: 0.8;
 }
 
+.auth-password-field {
+  position: relative;
+}
+
+.auth-password-field .form-control {
+  padding-right: 5.4rem;
+}
+
+.auth-password-toggle.btn {
+  position: absolute;
+  top: 50%;
+  right: 0.45rem;
+  min-width: 4.5rem;
+  min-height: 2.15rem;
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.55rem;
+  color: #5a1a2a;
+  background-color: transparent;
+  border: 0;
+  border-radius: 0.45rem;
+  font-size: 0.8rem;
+  font-weight: 750;
+  transform: translateY(-50%);
+}
+
+.auth-password-toggle.btn:hover,
+.auth-password-toggle.btn:focus-visible {
+  color: #ffffff;
+  background-color: #c91845;
+}
+
+.auth-password-toggle.btn:focus-visible {
+  box-shadow: 0 0 0 0.18rem rgba(230, 30, 77, 0.3);
+}
+
+.auth-card fieldset:disabled .auth-password-toggle.btn {
+  color: #777d84;
+  background-color: transparent;
+}
+
 .auth-help {
   margin-top: 0.45rem;
   margin-bottom: 0;

--- a/Catacombs/client/src/components/auth/ChangePassword.js
+++ b/Catacombs/client/src/components/auth/ChangePassword.js
@@ -1,0 +1,142 @@
+import React, { useContext, useState } from "react";
+import {
+  Button,
+  Container,
+  Form,
+  FormGroup,
+  Spinner,
+} from "reactstrap";
+import { UserContext } from "../Repositories/UserProvider";
+import Swal from "../../sweetAlert";
+import PasswordInput from "./PasswordInput";
+import "./Auth.css";
+
+export default function ChangePassword() {
+  const { changePassword } = useContext(UserContext);
+
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [confirmNewPassword, setConfirmNewPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const changePasswordSubmit = async (event) => {
+    event.preventDefault();
+
+    if (newPassword !== confirmNewPassword) {
+      await Swal.fire({
+        title: "Passwords do not match",
+        text: "Please enter the same new password in both fields.",
+        icon: "warning",
+        confirmButtonText: "Try again",
+      });
+      return;
+    }
+
+    if (currentPassword === newPassword) {
+      await Swal.fire({
+        title: "Choose a new password",
+        text: "Your new password must be different from your current password.",
+        icon: "warning",
+        confirmButtonText: "Try again",
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await changePassword({
+        currentPassword,
+        newPassword,
+        confirmNewPassword,
+      });
+      await Swal.fire({
+        title: "Password changed",
+        text: "Your password was updated. Please log in again.",
+        icon: "success",
+        confirmButtonText: "Continue to login",
+      });
+    } catch (error) {
+      await Swal.fire({
+        title: "Unable to change password",
+        text: error.message,
+        icon: "error",
+        confirmButtonText: "Try again",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Container className="auth-page">
+      <section
+        className="auth-card"
+        aria-labelledby="change-password-heading"
+      >
+        <p className="auth-eyebrow">Account security</p>
+        <h1 id="change-password-heading">Change password</h1>
+        <p className="auth-intro">
+          Confirm your current password, then choose a new one.
+        </p>
+
+        <Form onSubmit={changePasswordSubmit} aria-busy={isSubmitting}>
+          <fieldset disabled={isSubmitting}>
+            <FormGroup>
+              <PasswordInput
+                id="currentPassword"
+                label="Current password"
+                value={currentPassword}
+                required
+                maxLength="128"
+                autoComplete="current-password"
+                autoFocus
+                onChange={(event) => setCurrentPassword(event.target.value)}
+              />
+            </FormGroup>
+            <FormGroup>
+              <PasswordInput
+                id="newPassword"
+                label="New password"
+                value={newPassword}
+                required
+                minLength="8"
+                maxLength="128"
+                autoComplete="new-password"
+                aria-describedby="new-password-help"
+                onChange={(event) => setNewPassword(event.target.value)}
+              />
+              <p id="new-password-help" className="auth-help">
+                Use at least 8 characters and choose something different.
+              </p>
+            </FormGroup>
+            <FormGroup>
+              <PasswordInput
+                id="confirmNewPassword"
+                label="Confirm new password"
+                value={confirmNewPassword}
+                required
+                minLength="8"
+                maxLength="128"
+                autoComplete="new-password"
+                onChange={(event) =>
+                  setConfirmNewPassword(event.target.value)
+                }
+              />
+            </FormGroup>
+            <Button className="auth-submit" type="submit">
+              {isSubmitting ? (
+                <>
+                  <Spinner size="sm" aria-hidden="true" />
+                  <span>Changing password...</span>
+                </>
+              ) : (
+                "Change password"
+              )}
+            </Button>
+          </fieldset>
+        </Form>
+      </section>
+    </Container>
+  );
+}

--- a/Catacombs/client/src/components/auth/Login.js
+++ b/Catacombs/client/src/components/auth/Login.js
@@ -11,6 +11,7 @@ import {
 import { Link, useNavigate } from "react-router-dom";
 import { UserContext } from "../Repositories/UserProvider";
 import Swal from "../../sweetAlert";
+import PasswordInput from "./PasswordInput";
 import "./Auth.css";
 
 export default function Login() {
@@ -65,10 +66,9 @@ export default function Login() {
               />
             </FormGroup>
             <FormGroup>
-              <Label htmlFor="password">Password</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
+                label="Password"
                 value={password}
                 required
                 maxLength="128"

--- a/Catacombs/client/src/components/auth/PasswordInput.js
+++ b/Catacombs/client/src/components/auth/PasswordInput.js
@@ -1,0 +1,43 @@
+import React, { useState } from "react";
+import { Button, Input, Label } from "reactstrap";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faEye, faEyeSlash } from "@fortawesome/free-solid-svg-icons";
+
+export default function PasswordInput({
+  id,
+  label,
+  value,
+  onChange,
+  ...inputProps
+}) {
+  const [isVisible, setIsVisible] = useState(false);
+  const action = isVisible ? "Hide" : "Show";
+
+  return (
+    <>
+      <Label htmlFor={id}>{label}</Label>
+      <div className="auth-password-field">
+        <Input
+          {...inputProps}
+          id={id}
+          type={isVisible ? "text" : "password"}
+          value={value}
+          onChange={onChange}
+        />
+        <Button
+          className="auth-password-toggle"
+          type="button"
+          aria-label={`${action} ${label.toLowerCase()}`}
+          aria-pressed={isVisible}
+          onClick={() => setIsVisible((visible) => !visible)}
+        >
+          <FontAwesomeIcon
+            icon={isVisible ? faEyeSlash : faEye}
+            aria-hidden="true"
+          />
+          <span>{action}</span>
+        </Button>
+      </div>
+    </>
+  );
+}

--- a/Catacombs/client/src/components/auth/Register.js
+++ b/Catacombs/client/src/components/auth/Register.js
@@ -11,6 +11,7 @@ import {
 import { Link, useNavigate } from "react-router-dom";
 import { UserContext } from "../Repositories/UserProvider";
 import Swal from "../../sweetAlert";
+import PasswordInput from "./PasswordInput";
 import "./Auth.css";
 
 export default function Register() {
@@ -97,10 +98,9 @@ export default function Register() {
               />
             </FormGroup>
             <FormGroup>
-              <Label htmlFor="password">Password</Label>
-              <Input
+              <PasswordInput
                 id="password"
-                type="password"
+                label="Password"
                 value={password}
                 required
                 minLength="8"
@@ -114,10 +114,9 @@ export default function Register() {
               </p>
             </FormGroup>
             <FormGroup>
-              <Label htmlFor="confirmPassword">Confirm password</Label>
-              <Input
+              <PasswordInput
                 id="confirmPassword"
-                type="password"
+                label="Confirm password"
                 value={confirmPassword}
                 required
                 minLength="8"

--- a/Catacombs/client/src/components/auth/Register.js
+++ b/Catacombs/client/src/components/auth/Register.js
@@ -103,14 +103,14 @@ export default function Register() {
                 type="password"
                 value={password}
                 required
-                minLength="15"
+                minLength="8"
                 maxLength="128"
                 autoComplete="new-password"
                 aria-describedby="password-help"
                 onChange={(event) => setPassword(event.target.value)}
               />
               <p id="password-help" className="auth-help">
-                Use at least 15 characters. A memorable passphrase works well.
+                Use at least 8 characters. Longer passwords are more secure.
               </p>
             </FormGroup>
             <FormGroup>
@@ -120,7 +120,7 @@ export default function Register() {
                 type="password"
                 value={confirmPassword}
                 required
-                minLength="15"
+                minLength="8"
                 maxLength="128"
                 autoComplete="new-password"
                 onChange={(event) => setConfirmPassword(event.target.value)}


### PR DESCRIPTION
## Description

This PR improves the password and account settings in Catacombs. It makes passwords easier to manage while keeping the account features secure.

## Changes

- Lowered the minimum password length from 15 characters to 8
- Added Show and Hide buttons to password fields
- Added a protected Change Password page
- Requires the current password before allowing a change
- Requires the new password to be entered twice and match
- Prevents reusing the current password
- Stores the new password as a secure hash
- Signs the user out after changing their password
- Added rate limiting and antiforgery protection to password changes
- Moved Change Password and Log out into a username dropdown

## Testing

- All 21 backend tests pass
- The React production build completes successfully
- Registration accepts an eight-character password
- Password visibility buttons work on the account forms
- Incorrect and mismatched passwords are rejected
- A changed password works after logging back in