### PR TITLE
Add personal home dashboard

### DIFF
--- a/Catacombs.Tests/SecurityIntegrationTests.cs
+++ b/Catacombs.Tests/SecurityIntegrationTests.cs
@@ -241,6 +241,12 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
             HttpStatusCode.Unauthorized,
             anonymousResponse.StatusCode);
 
+        var anonymousSummaryResponse =
+            await _client.GetAsync("/api/movies/summary");
+        Assert.Equal(
+            HttpStatusCode.Unauthorized,
+            anonymousSummaryResponse.StatusCode);
+
         var anonymousTmdbResponse =
             await _client.GetAsync("/api/tmdb/movies/popular");
         Assert.Equal(
@@ -490,6 +496,54 @@ public sealed class SecurityIntegrationTests : IAsyncLifetime
             movie => movie.GetProperty("movieId").GetInt32()
                 == secondTmdbMovieId
                 && movie.GetProperty("watched").GetBoolean());
+    }
+
+    [Fact]
+    public async Task MovieSummaryCountsTheCurrentUsersCollection()
+    {
+        await RegisterAndLoginAsync(_client, "movie-summary");
+
+        var movieStates = new[]
+        {
+            new { MovieId = 44001, Watched = false, Rating = 0 },
+            new { MovieId = 44002, Watched = true, Rating = 1 },
+            new { MovieId = 44003, Watched = true, Rating = -1 },
+            new { MovieId = 44004, Watched = true, Rating = 0 }
+        };
+
+        foreach (var movieState in movieStates)
+        {
+            var response = await SendWithAntiforgeryAsync(
+                _client,
+                HttpMethod.Put,
+                "/api/movies/status",
+                NewMovieStatusRequest(
+                    movieState.MovieId,
+                    movieState.Watched,
+                    movieState.Rating));
+
+            Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        }
+
+        var summaryResponse =
+            await _client.GetAsync("/api/movies/summary");
+        Assert.Equal(HttpStatusCode.OK, summaryResponse.StatusCode);
+
+        using var document = await ReadJsonAsync(summaryResponse);
+        var summary = document.RootElement;
+
+        Assert.Equal(
+            1,
+            summary.GetProperty("watchlistCount").GetInt32());
+        Assert.Equal(
+            3,
+            summary.GetProperty("watchedCount").GetInt32());
+        Assert.Equal(
+            1,
+            summary.GetProperty("likedCount").GetInt32());
+        Assert.Equal(
+            1,
+            summary.GetProperty("dislikedCount").GetInt32());
     }
 
     [Fact]

--- a/Catacombs/Controllers/MoviesController.cs
+++ b/Catacombs/Controllers/MoviesController.cs
@@ -40,6 +40,15 @@ namespace Catacombs.Controllers
                 userId => Ok(_moviesRepository.GetCollection(userId)));
         }
 
+        [HttpGet("summary")]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status401Unauthorized)]
+        public IActionResult GetSummary()
+        {
+            return ForCurrentUser(
+                userId => Ok(_moviesRepository.GetSummary(userId)));
+        }
+
         [HttpGet("seen")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status401Unauthorized)]

--- a/Catacombs/Models/MovieCollectionSummary.cs
+++ b/Catacombs/Models/MovieCollectionSummary.cs
@@ -1,0 +1,10 @@
+namespace Catacombs.Models
+{
+    public sealed class MovieCollectionSummary
+    {
+        public int WatchlistCount { get; init; }
+        public int WatchedCount { get; init; }
+        public int LikedCount { get; init; }
+        public int DislikedCount { get; init; }
+    }
+}

--- a/Catacombs/Repositories/IMoviesRepository.cs
+++ b/Catacombs/Repositories/IMoviesRepository.cs
@@ -9,6 +9,7 @@ namespace Catacombs.Repositories
         Movies GetMovieByTmdbId(int movieId, int userId);
         void Add(Movies movie, int userId);
         Movies SetStatus(Movies movie, int userId);
+        MovieCollectionSummary GetSummary(int userId);
         List<Movies> GetCollection(int userId);
         List<Movies> GetAllMovies(int userId);
         List<Movies> GetAllSeenMovies(int userId);

--- a/Catacombs/Repositories/MoviesRepository.cs
+++ b/Catacombs/Repositories/MoviesRepository.cs
@@ -54,6 +54,43 @@ namespace Catacombs.Repositories
                 userId);
         }
 
+        public MovieCollectionSummary GetSummary(int userId)
+        {
+            using var connection = Connection;
+            connection.Open();
+
+            using var command = connection.CreateCommand();
+            command.CommandText = @"
+                SELECT (COUNT(*) FILTER (
+                            WHERE watched = false))::integer,
+                       (COUNT(*) FILTER (
+                            WHERE watched = true))::integer,
+                       (COUNT(*) FILTER (
+                            WHERE watched = true
+                              AND rating = 1))::integer,
+                       (COUNT(*) FILTER (
+                            WHERE watched = true
+                              AND rating = -1))::integer
+                  FROM movies
+                 WHERE user_id = @userId";
+            DbUtils.AddParameter(
+                command,
+                "@userId",
+                userId,
+                DbType.Int32);
+
+            using var reader = command.ExecuteReader();
+            reader.Read();
+
+            return new MovieCollectionSummary
+            {
+                WatchlistCount = reader.GetInt32(0),
+                WatchedCount = reader.GetInt32(1),
+                LikedCount = reader.GetInt32(2),
+                DislikedCount = reader.GetInt32(3)
+            };
+        }
+
         public List<Movies> GetAllMovies(int userId)
         {
             return GetMovies(

--- a/Catacombs/client/src/components/Home.css
+++ b/Catacombs/client/src/components/Home.css
@@ -181,6 +181,86 @@
     text-transform: uppercase;
 }
 
+.home-summary {
+    padding-top: clamp(2.75rem, 6vw, 4.5rem);
+}
+
+.home-summary-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.home-summary-card {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.2rem 0.85rem;
+    align-items: center;
+    padding: 1.15rem;
+    color: #f8f9fa;
+    background:
+        linear-gradient(
+            145deg,
+            rgba(38, 42, 46, 0.96),
+            rgba(27, 30, 33, 0.96)
+        );
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 0.85rem;
+    box-shadow: 0 0.6rem 1.35rem rgba(0, 0, 0, 0.16);
+    text-decoration: none;
+    transition:
+        border-color 150ms ease,
+        box-shadow 150ms ease,
+        transform 150ms ease;
+}
+
+.home-summary-card:hover,
+.home-summary-card:focus-visible {
+    color: #ffffff;
+    border-color: rgba(230, 30, 77, 0.64);
+    box-shadow: 0 0.85rem 1.8rem rgba(0, 0, 0, 0.24);
+    transform: translateY(-2px);
+}
+
+.home-summary-icon {
+    width: 2.85rem;
+    height: 2.85rem;
+    grid-row: span 2;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    color: #ff718f;
+    background-color: rgba(230, 30, 77, 0.12);
+    border: 1px solid rgba(230, 30, 77, 0.25);
+    border-radius: 0.7rem;
+}
+
+.home-summary-value {
+    overflow: hidden;
+    font-size: clamp(1.65rem, 4vw, 2.2rem);
+    font-weight: 800;
+    line-height: 1;
+    text-overflow: ellipsis;
+}
+
+.home-summary-label {
+    overflow: hidden;
+    color: #afb5ba;
+    font-size: 0.82rem;
+    line-height: 1.25;
+    text-overflow: ellipsis;
+}
+
+.home-summary-error {
+    margin: 0;
+    padding: 1rem 1.15rem;
+    color: #ffd6df;
+    background-color: rgba(111, 42, 59, 0.45);
+    border: 1px solid rgba(198, 91, 118, 0.48);
+    border-radius: 0.85rem;
+}
+
 .home-destinations {
     padding-top: clamp(2.75rem, 6vw, 4.5rem);
 }
@@ -284,6 +364,10 @@
     .home-arch {
         width: min(100%, 12rem);
     }
+
+    .home-summary-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
 }
 
 @media (max-width: 767.98px) {
@@ -308,5 +392,9 @@
     .home-primary-action,
     .home-secondary-action {
         width: 100%;
+    }
+
+    .home-summary-grid {
+        grid-template-columns: 1fr;
     }
 }

--- a/Catacombs/client/src/components/Home.css
+++ b/Catacombs/client/src/components/Home.css
@@ -261,6 +261,206 @@
     border-radius: 0.85rem;
 }
 
+.home-watchlist {
+    padding-top: clamp(2.75rem, 6vw, 4.5rem);
+}
+
+.home-watchlist-heading {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    justify-content: space-between;
+    margin-bottom: 1.35rem;
+}
+
+.home-watchlist-heading .home-section-heading {
+    margin-bottom: 0;
+}
+
+.home-watchlist-link {
+    padding-bottom: 0.2rem;
+    color: #ff8ca4;
+    font-size: 0.9rem;
+    font-weight: 750;
+    text-decoration: none;
+}
+
+.home-watchlist-link:hover,
+.home-watchlist-link:focus-visible {
+    color: #ffffff;
+    text-decoration: underline;
+}
+
+.home-watchlist-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 0.9fr) minmax(20rem, 1.1fr);
+    gap: 1rem;
+    align-items: stretch;
+}
+
+.home-watchlist-preview {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.home-watchlist-movie {
+    min-width: 0;
+    display: grid;
+    grid-template-columns: 4rem minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: center;
+    padding: 0.75rem;
+    background-color: rgba(32, 36, 40, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 0.8rem;
+}
+
+.home-watchlist-movie img {
+    width: 4rem;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 0.5rem;
+}
+
+.home-watchlist-movie h3 {
+    margin: 0;
+    overflow: hidden;
+    font-size: 1rem;
+    line-height: 1.3;
+    text-overflow: ellipsis;
+}
+
+.home-watchlist-movie p {
+    margin: 0.3rem 0 0;
+    color: #9fa6ac;
+    font-size: 0.8rem;
+}
+
+.home-picker {
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: center;
+    padding: clamp(1.25rem, 4vw, 2rem);
+    background:
+        radial-gradient(
+            circle at 85% 10%,
+            rgba(230, 30, 77, 0.15),
+            transparent 15rem
+        ),
+        rgba(25, 28, 31, 0.96);
+    border: 1px solid rgba(230, 30, 77, 0.34);
+    border-radius: 0.9rem;
+    box-shadow: 0 0.85rem 1.8rem rgba(0, 0, 0, 0.2);
+}
+
+.home-picker > h3 {
+    margin-bottom: 0.55rem;
+    font-size: clamp(1.45rem, 3vw, 2rem);
+}
+
+.home-picker-intro {
+    max-width: 34rem;
+    margin-bottom: 1.25rem;
+    color: #b8bdc2;
+    line-height: 1.55;
+}
+
+.home-picker-result {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 7rem minmax(0, 1fr);
+    gap: 1rem;
+    align-items: start;
+    margin-bottom: 1.25rem;
+}
+
+.home-picker-result img {
+    width: 7rem;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.65rem;
+    box-shadow: 0 0.7rem 1.3rem rgba(0, 0, 0, 0.28);
+}
+
+.home-picker-result span {
+    color: #ff8ca4;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.home-picker-result h3 {
+    margin: 0.25rem 0 0.55rem;
+    font-size: clamp(1.35rem, 3vw, 1.85rem);
+}
+
+.home-picker-result p {
+    display: -webkit-box;
+    margin: 0;
+    overflow: hidden;
+    color: #b8bdc2;
+    line-height: 1.5;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 4;
+}
+
+.home-picker-button {
+    min-height: 3rem;
+    display: inline-flex;
+    gap: 0.55rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0.7rem 1.15rem;
+    color: #ffffff;
+    background-color: #e61e4d;
+    border: 1px solid #e61e4d;
+    border-radius: 0.65rem;
+    box-shadow: 0 0.45rem 1.1rem rgba(230, 30, 77, 0.25);
+    font-weight: 750;
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        box-shadow 150ms ease,
+        transform 150ms ease;
+}
+
+.home-picker-button:hover,
+.home-picker-button:focus-visible {
+    background-color: #c91845;
+    border-color: #ff5579;
+    box-shadow: 0 0.6rem 1.25rem rgba(230, 30, 77, 0.32);
+    transform: translateY(-1px);
+}
+
+.home-picker-button:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 0.2rem rgba(255, 85, 121, 0.35);
+}
+
+.home-watchlist-loading,
+.home-watchlist-empty {
+    margin: 0;
+    padding: 1.25rem;
+    color: #b8bdc2;
+    background-color: rgba(32, 36, 40, 0.82);
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 0.85rem;
+}
+
+.home-watchlist-empty p {
+    margin: 0 0 0.55rem;
+}
+
+.home-watchlist-empty a {
+    color: #ff8ca4;
+    font-weight: 750;
+}
+
 .home-destinations {
     padding-top: clamp(2.75rem, 6vw, 4.5rem);
 }
@@ -368,10 +568,30 @@
     .home-summary-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
+
+    .home-watchlist-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .home-watchlist-preview {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .home-watchlist-movie {
+        grid-template-columns: 3.5rem minmax(0, 1fr);
+    }
+
+    .home-watchlist-movie img {
+        width: 3.5rem;
+    }
 }
 
 @media (max-width: 767.98px) {
     .home-destination-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .home-watchlist-preview {
         grid-template-columns: 1fr;
     }
 }
@@ -396,5 +616,22 @@
 
     .home-summary-grid {
         grid-template-columns: 1fr;
+    }
+
+    .home-watchlist-heading {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .home-picker-result {
+        grid-template-columns: 5.5rem minmax(0, 1fr);
+    }
+
+    .home-picker-result img {
+        width: 5.5rem;
+    }
+
+    .home-picker-button {
+        width: 100%;
     }
 }

--- a/Catacombs/client/src/components/Home.js
+++ b/Catacombs/client/src/components/Home.js
@@ -7,20 +7,32 @@ import {
     faGem,
     faHeart,
     faMagnifyingGlass,
+    faShuffle,
     faStar,
     faThumbsDown
 } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { Container } from "reactstrap";
+import { getMoviePosterUrl } from "./Movies/MovieCardContent";
 import { MovieContext } from "./Repositories/MovieProvider";
 import { UserContext } from "./Repositories/UserProvider";
 import "./Home.css";
 
+const getReleaseYear = (releaseDate) => {
+    const year = Number(releaseDate?.split("-")[0]);
+    return Number.isInteger(year) && year > 1800
+        ? year
+        : "Release date unavailable";
+};
+
 export const Home = () => {
     const { userProfile } = useContext(UserContext);
-    const { getMovieSummary } = useContext(MovieContext);
+    const { getMovieSummary, getWatchlist } = useContext(MovieContext);
     const [movieSummary, setMovieSummary] = useState(null);
     const [summaryError, setSummaryError] = useState("");
+    const [watchlist, setWatchlist] = useState(null);
+    const [watchlistError, setWatchlistError] = useState("");
+    const [selectedMovie, setSelectedMovie] = useState(null);
 
     useEffect(() => {
         let isCancelled = false;
@@ -37,10 +49,34 @@ export const Home = () => {
                 }
             });
 
+        getWatchlist()
+            .then((movies) => {
+                if (!isCancelled) {
+                    setWatchlist(movies);
+                }
+            })
+            .catch((error) => {
+                if (!isCancelled) {
+                    setWatchlistError(error.message);
+                }
+            });
+
         return () => {
             isCancelled = true;
         };
-    }, [getMovieSummary]);
+    }, [getMovieSummary, getWatchlist]);
+
+    const chooseWatchlistMovie = () => {
+        if (!watchlist?.length) {
+            return;
+        }
+
+        const choices = watchlist.length > 1 && selectedMovie
+            ? watchlist.filter((movie) => movie.id !== selectedMovie.id)
+            : watchlist;
+        const selectedIndex = Math.floor(Math.random() * choices.length);
+        setSelectedMovie(choices[selectedIndex]);
+    };
 
     const collectionStats = [
         {
@@ -181,6 +217,130 @@ export const Home = () => {
                                     </span>
                                 </Link>
                             ))}
+                        </div>
+                    )}
+                </section>
+
+                <section
+                    className="home-watchlist"
+                    aria-labelledby="home-watchlist-heading"
+                    aria-busy={!watchlist && !watchlistError}
+                >
+                    <div className="home-watchlist-heading">
+                        <div className="home-section-heading">
+                            <p className="home-eyebrow">Waiting in the dark</p>
+                            <h2 id="home-watchlist-heading">
+                                Your watchlist
+                            </h2>
+                        </div>
+                        {watchlist?.length > 0 && (
+                            <Link
+                                className="home-watchlist-link"
+                                to="/movies/watchlist"
+                            >
+                                View full watchlist
+                            </Link>
+                        )}
+                    </div>
+
+                    {watchlistError ? (
+                        <p className="home-summary-error" role="alert">
+                            Your watchlist preview could not be loaded.
+                            Please refresh the page and try again.
+                        </p>
+                    ) : watchlist === null ? (
+                        <p className="home-watchlist-loading" role="status">
+                            Opening your watchlist...
+                        </p>
+                    ) : watchlist.length === 0 ? (
+                        <div className="home-watchlist-empty">
+                            <p>
+                                Your watchlist is empty. Add a few movies
+                                before asking the Catacombs to choose.
+                            </p>
+                            <Link to="/movies/popular">
+                                Find something to watch
+                            </Link>
+                        </div>
+                    ) : (
+                        <div className="home-watchlist-layout">
+                            <div
+                                className="home-watchlist-preview"
+                                aria-label="Watchlist preview"
+                            >
+                                {watchlist.slice(0, 3).map((movie) => (
+                                    <article
+                                        className="home-watchlist-movie"
+                                        key={movie.id}
+                                    >
+                                        <img
+                                            src={getMoviePosterUrl(
+                                                movie.poster_path
+                                            )}
+                                            alt={`${movie.title} poster`}
+                                            loading="lazy"
+                                        />
+                                        <div>
+                                            <h3>{movie.title}</h3>
+                                            <p>
+                                                {getReleaseYear(
+                                                    movie.release_date
+                                                )}
+                                            </p>
+                                        </div>
+                                    </article>
+                                ))}
+                            </div>
+
+                            <aside className="home-picker">
+                                <p className="home-eyebrow">
+                                    Tonight's descent
+                                </p>
+                                {selectedMovie ? (
+                                    <div
+                                        className="home-picker-result"
+                                        aria-live="polite"
+                                    >
+                                        <img
+                                            src={getMoviePosterUrl(
+                                                selectedMovie.poster_path
+                                            )}
+                                            alt={
+                                                `${selectedMovie.title} poster`
+                                            }
+                                        />
+                                        <div>
+                                            <span>The Catacombs chose</span>
+                                            <h3>{selectedMovie.title}</h3>
+                                            <p>
+                                                {selectedMovie.overview ||
+                                                    "No overview is available."}
+                                            </p>
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <>
+                                        <h3>Can't decide what to watch?</h3>
+                                        <p className="home-picker-intro">
+                                            Let the Catacombs choose one
+                                            movie from your watchlist.
+                                        </p>
+                                    </>
+                                )}
+                                <button
+                                    type="button"
+                                    className="home-picker-button"
+                                    onClick={chooseWatchlistMovie}
+                                >
+                                    <FontAwesomeIcon
+                                        icon={faShuffle}
+                                        aria-hidden="true"
+                                    />
+                                    {selectedMovie
+                                        ? "Choose another"
+                                        : "Choose something for me"}
+                                </button>
+                            </aside>
                         </div>
                     )}
                 </section>

--- a/Catacombs/client/src/components/Home.js
+++ b/Catacombs/client/src/components/Home.js
@@ -1,18 +1,73 @@
-import React, { useContext } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faBookmark,
+    faEye,
     faFire,
+    faGem,
+    faHeart,
     faMagnifyingGlass,
-    faStar
+    faStar,
+    faThumbsDown
 } from "@fortawesome/free-solid-svg-icons";
 import { Link } from "react-router-dom";
 import { Container } from "reactstrap";
+import { MovieContext } from "./Repositories/MovieProvider";
 import { UserContext } from "./Repositories/UserProvider";
 import "./Home.css";
 
 export const Home = () => {
     const { userProfile } = useContext(UserContext);
+    const { getMovieSummary } = useContext(MovieContext);
+    const [movieSummary, setMovieSummary] = useState(null);
+    const [summaryError, setSummaryError] = useState("");
+
+    useEffect(() => {
+        let isCancelled = false;
+
+        getMovieSummary()
+            .then((summary) => {
+                if (!isCancelled) {
+                    setMovieSummary(summary);
+                }
+            })
+            .catch((error) => {
+                if (!isCancelled) {
+                    setSummaryError(error.message);
+                }
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [getMovieSummary]);
+
+    const collectionStats = [
+        {
+            label: "In your watchlist",
+            value: movieSummary?.watchlistCount,
+            icon: faBookmark,
+            path: "/movies/watchlist"
+        },
+        {
+            label: "Movies watched",
+            value: movieSummary?.watchedCount,
+            icon: faEye,
+            path: "/movies/seen"
+        },
+        {
+            label: "Movies you liked",
+            value: movieSummary?.likedCount,
+            icon: faHeart,
+            path: "/movies/liked"
+        },
+        {
+            label: "In the reject pile",
+            value: movieSummary?.dislikedCount,
+            icon: faThumbsDown,
+            path: "/movies/disliked"
+        }
+    ];
 
     const destinations = [
         {
@@ -34,10 +89,10 @@ export const Home = () => {
             path: "/movies/search"
         },
         {
-            title: "My Watch List",
-            description: "Return to the movies you saved for later.",
-            icon: faBookmark,
-            path: "/movies/watchlist"
+            title: "Hidden Gems",
+            description: "Dig up overlooked horror movies worth discovering.",
+            icon: faGem,
+            path: "/movies/hidden-gems"
         }
     ];
 
@@ -87,6 +142,47 @@ export const Home = () => {
                             <small>Horror movie archive</small>
                         </div>
                     </div>
+                </section>
+
+                <section
+                    className="home-summary"
+                    aria-labelledby="home-summary-heading"
+                    aria-busy={!movieSummary && !summaryError}
+                >
+                    <div className="home-section-heading">
+                        <p className="home-eyebrow">Your collection</p>
+                        <h2 id="home-summary-heading">At a glance</h2>
+                    </div>
+
+                    {summaryError ? (
+                        <p className="home-summary-error" role="alert">
+                            Your collection totals could not be loaded.
+                            Please refresh the page and try again.
+                        </p>
+                    ) : (
+                        <div className="home-summary-grid">
+                            {collectionStats.map((stat) => (
+                                <Link
+                                    className="home-summary-card"
+                                    to={stat.path}
+                                    key={stat.path}
+                                >
+                                    <span className="home-summary-icon">
+                                        <FontAwesomeIcon
+                                            icon={stat.icon}
+                                            aria-hidden="true"
+                                        />
+                                    </span>
+                                    <span className="home-summary-value">
+                                        {stat.value ?? "—"}
+                                    </span>
+                                    <span className="home-summary-label">
+                                        {stat.label}
+                                    </span>
+                                </Link>
+                            ))}
+                        </div>
+                    )}
                 </section>
 
                 <section

--- a/Catacombs/client/src/components/Movies/MovieCardContent.js
+++ b/Catacombs/client/src/components/Movies/MovieCardContent.js
@@ -9,7 +9,7 @@ import {
 const posterBaseUrl = "https://image.tmdb.org/t/p/w342";
 const missingPoster = require("./images/broken-1.png");
 
-const posterUrl = (posterPath) => {
+export const getMoviePosterUrl = (posterPath) => {
     if (
         !posterPath ||
         posterPath === "string"
@@ -55,7 +55,7 @@ export const MovieCardContent = ({ movie }) => (
     <CardBody className="movie-card-body">
         <img
             className="movie-card-poster"
-            src={posterUrl(movie.poster_path)}
+            src={getMoviePosterUrl(movie.poster_path)}
             alt={`${movie.title} poster`}
             loading="lazy"
         />

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -252,6 +252,11 @@ export const MovieProvider = (props) => {
             .then(setMovies)
     }
 
+    const getMovieSummary = () => {
+        return apiFetch("/api/Movies/summary")
+            .then((response) => response.json())
+    }
+
     return (
         <MovieContext.Provider value={{
             movies,
@@ -275,6 +280,7 @@ export const MovieProvider = (props) => {
             deleteMovie,
             getAllLikedMovies,
             getAllDislikedMovies,
+            getMovieSummary,
             getMovieMetadata
         }}>
             {props.children}

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -218,9 +218,13 @@ export const MovieProvider = (props) => {
         return rememberSavedMovie(savedMovie)
     }
 
-    const getAllMovies = () => {
+    const getWatchlist = () => {
         return apiFetch("/api/Movies")
             .then((response) => response.json())
+    }
+
+    const getAllMovies = () => {
+        return getWatchlist()
             .then(setMovies)
     }
 
@@ -271,6 +275,7 @@ export const MovieProvider = (props) => {
             hiddenGems,
             addMovie,
             setMovieStatus,
+            getWatchlist,
             getAllMovies,
             searchMovies,
             comingSoon,


### PR DESCRIPTION
## Description

This PR turns the home page into a personal dashboard so users can quickly check their collection and choose something to watch.

## Changes

- Added watchlist, watched, liked, and disliked totals
- Made each collection total link to its matching My Movies page
- Added a preview of movies currently in the watchlist
- Added a link to open the full watchlist
- Added a random “Choose something for me” movie picker
- Added an option to choose another movie without immediately repeating the same result
- Added helpful loading, error, and empty-watchlist messages
- Added a private backend endpoint for the collection totals
- Added tests for the personal movie summary

## Testing

- The frontend builds successfully
- All 24 backend tests pass
- Collection totals only include the signed-in user’s movies
- Dashboard totals link to the correct pages
- The watchlist preview displays saved movies
- The random picker selects movies from the user’s watchlist