### PR TITLE
Movie details

### DIFF
--- a/Catacombs.Tests/TmdbClientTests.cs
+++ b/Catacombs.Tests/TmdbClientTests.cs
@@ -234,7 +234,7 @@ public sealed class TmdbClientTests
     }
 
     [Fact]
-    public async Task MetadataCombinesSocialIdsAndVideosInOneRequest()
+    public async Task MetadataCombinesDetailsExtrasInOneRequest()
     {
         var handler = new RecordingHandler();
         var client = CreateClient(handler, TestToken);
@@ -244,7 +244,8 @@ public sealed class TmdbClientTests
             CancellationToken.None);
 
         Assert.Equal(
-            "/3/movie/348?append_to_response=external_ids,videos" +
+            "/3/movie/348?append_to_response=" +
+            "external_ids,videos,watch%2Fproviders" +
             "&language=en-US",
             handler.RequestUri?.PathAndQuery);
         Assert.Equal(1, handler.RequestCount);

--- a/Catacombs/Services/Tmdb/TmdbClient.cs
+++ b/Catacombs/Services/Tmdb/TmdbClient.cs
@@ -186,7 +186,8 @@ namespace Catacombs.Services.Tmdb
                 $"movie/{FormatNumber(movieId)}",
                 new Dictionary<string, string>
                 {
-                    ["append_to_response"] = "external_ids,videos",
+                    ["append_to_response"] =
+                        "external_ids,videos,watch/providers",
                     ["language"] = "en-US"
                 },
                 cancellationToken);

--- a/Catacombs/client/src/components/ApplicationViews.js
+++ b/Catacombs/client/src/components/ApplicationViews.js
@@ -16,6 +16,7 @@ import { SeenMoviesList } from "./Movies/SeenMoviesList";
 import { LikedMoviesList } from "./Movies/LikedMoviesList";
 import { DislikedMoviesList } from "./Movies/DislikedMoviesList";
 import { SimilarMovieList } from "./Movies/SimilarMoviesList";
+import { MovieDetails } from "./Movies/MovieDetails";
 import { Home } from "./Home";
 import "./auth/Auth.css";
 
@@ -60,6 +61,7 @@ export default function ApplicationViews() {
             <Route path="/movies/comingsoon" element={<ComingSoonList />} />
             <Route path="/movies/nowplaying" element={<NowPlayingList />} />
             <Route path="/movies/similar/:id" element={<SimilarMovieList />} />
+            <Route path="/movies/details/:id" element={<MovieDetails />} />
 
 
             {/* My API Routes */}

--- a/Catacombs/client/src/components/Header.js
+++ b/Catacombs/client/src/components/Header.js
@@ -37,7 +37,8 @@ export default function Header() {
     "/movies/nowplaying",
     "/movies/comingsoon",
     "/movies/search",
-    "/movies/similar"
+    "/movies/similar",
+    "/movies/details"
   ].some(path => location.pathname.startsWith(path));
   const myMoviesIsActive = [
     "/movies/watchlist",

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -174,6 +174,30 @@
     box-shadow: 0 0.6rem 1.25rem rgba(0, 0, 0, 0.28);
 }
 
+.movie-card-poster-link {
+    width: 100%;
+    display: block;
+    align-self: start;
+    border-radius: 0.7rem;
+}
+
+.movie-card-poster-link:focus-visible {
+    box-shadow: 0 0 0 0.2rem rgba(255, 85, 121, 0.35);
+    outline: none;
+}
+
+.movie-card-poster-link .movie-card-poster {
+    transition:
+        border-color 150ms ease,
+        transform 150ms ease;
+}
+
+.movie-card-poster-link:hover .movie-card-poster,
+.movie-card-poster-link:focus-visible .movie-card-poster {
+    border-color: #ff5579;
+    transform: translateY(-2px);
+}
+
 .movie-card-details {
     min-width: 0;
     display: flex;
@@ -189,6 +213,16 @@
     line-height: 1.25;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
+}
+
+.movie-card-title a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.movie-card-title a:hover,
+.movie-card-title a:focus-visible {
+    color: #ff8ca4;
 }
 
 .movie-card-meta {
@@ -446,6 +480,15 @@
         transform 150ms ease;
 }
 
+.movie-icon-button--labeled.btn {
+    width: auto;
+    min-width: 2.7rem;
+    gap: 0.5rem;
+    padding: 0 0.85rem;
+    font-size: 0.9rem;
+    font-weight: 750;
+}
+
 .movie-icon-button::before,
 .movie-icon-button::after {
     position: absolute;
@@ -614,6 +657,10 @@
     }
 
     .movie-card-poster {
+        width: 100%;
+    }
+
+    .movie-card-poster-link {
         width: min(100%, 14rem);
         justify-self: center;
     }

--- a/Catacombs/client/src/components/Movies/MovieActionButton.js
+++ b/Catacombs/client/src/components/Movies/MovieActionButton.js
@@ -7,11 +7,13 @@ export const MovieActionButton = ({
     label,
     onClick,
     variant,
+    text,
     isDisabled = false,
     isSelected = false
 }) => {
     const className = [
         "movie-icon-button",
+        text ? "movie-icon-button--labeled" : "",
         variant ? `movie-icon-button--${variant}` : ""
     ].filter(Boolean).join(" ");
 
@@ -33,6 +35,7 @@ export const MovieActionButton = ({
             data-tooltip={label}
         >
             <FontAwesomeIcon icon={icon} aria-hidden="true" />
+            {text && <span>{text}</span>}
         </Button>
     );
 };

--- a/Catacombs/client/src/components/Movies/MovieCardContent.js
+++ b/Catacombs/client/src/components/Movies/MovieCardContent.js
@@ -5,6 +5,7 @@ import {
     CardText,
     CardTitle
 } from "reactstrap";
+import { Link } from "react-router-dom";
 
 const posterBaseUrl = "https://image.tmdb.org/t/p/w342";
 const missingPoster = require("./images/broken-1.png");
@@ -51,17 +52,27 @@ const formatRating = (rating) => {
     return `${numericRating.toFixed(1)} / 10`;
 };
 
-export const MovieCardContent = ({ movie }) => (
-    <CardBody className="movie-card-body">
-        <img
-            className="movie-card-poster"
-            src={getMoviePosterUrl(movie.poster_path)}
-            alt={`${movie.title} poster`}
-            loading="lazy"
-        />
+export const MovieCardContent = ({ movie }) => {
+    const tmdbMovieId = movie.movieId ?? movie.id;
+    const detailsPath = `/movies/details/${tmdbMovieId}`;
+
+    return (
+        <CardBody className="movie-card-body">
+        <Link
+            className="movie-card-poster-link"
+            to={detailsPath}
+            aria-label={`View details for ${movie.title}`}
+        >
+            <img
+                className="movie-card-poster"
+                src={getMoviePosterUrl(movie.poster_path)}
+                alt={`${movie.title} poster`}
+                loading="lazy"
+            />
+        </Link>
         <div className="movie-card-details">
             <CardTitle className="movie-card-title" tag="h2">
-                {movie.title}
+                <Link to={detailsPath}>{movie.title}</Link>
             </CardTitle>
             <div className="movie-card-meta">
                 <CardSubtitle
@@ -90,4 +101,5 @@ export const MovieCardContent = ({ movie }) => (
             </CardText>
         </div>
     </CardBody>
-);
+    );
+};

--- a/Catacombs/client/src/components/Movies/MovieCollectionActions.js
+++ b/Catacombs/client/src/components/Movies/MovieCollectionActions.js
@@ -17,7 +17,10 @@ import {
     showViewingStatusSaved
 } from "./movieAlerts";
 
-export const MovieCollectionActions = ({ movie }) => {
+export const MovieCollectionActions = ({
+    movie,
+    showLabels = false
+}) => {
     const {
         addMovie,
         getSavedMovie,
@@ -105,6 +108,13 @@ export const MovieCollectionActions = ({ movie }) => {
                     variant={isOnWatchlist ? "selected" : undefined}
                     isDisabled={isOnWatchlist}
                     isSelected={isOnWatchlist}
+                    text={
+                        showLabels
+                            ? isOnWatchlist
+                                ? "In watchlist"
+                                : "Add to watchlist"
+                            : undefined
+                    }
                 />
             )}
             <MovieActionButton
@@ -117,6 +127,13 @@ export const MovieCollectionActions = ({ movie }) => {
                 onClick={handleViewingStatus}
                 variant={isWatched ? "selected" : undefined}
                 isSelected={isWatched}
+                text={
+                    showLabels
+                        ? isWatched
+                            ? "Change rating"
+                            : "I've seen this"
+                        : undefined
+                }
             />
         </>
     );

--- a/Catacombs/client/src/components/Movies/MovieDetails.css
+++ b/Catacombs/client/src/components/Movies/MovieDetails.css
@@ -1,0 +1,256 @@
+.movie-details-page {
+    min-height: calc(100vh - 72px);
+    padding: 1.25rem 0 4rem;
+    background:
+        radial-gradient(
+            circle at 75% 8%,
+            rgba(230, 30, 77, 0.1),
+            transparent 30rem
+        );
+}
+
+.movie-details-back {
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    margin-bottom: 1rem;
+    padding: 0.5rem 0.65rem;
+    color: #c9cdd1;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.55rem;
+    font-weight: 700;
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        color 150ms ease;
+}
+
+.movie-details-back:hover,
+.movie-details-back:focus-visible {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.12);
+}
+
+.movie-details-card {
+    position: relative;
+    min-height: 38rem;
+    overflow: hidden;
+    background-color: #181b1e;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    border-radius: 1.2rem;
+    box-shadow: 0 1.5rem 3.5rem rgba(0, 0, 0, 0.34);
+}
+
+.movie-details-backdrop {
+    position: absolute;
+    inset: 0 0 auto;
+    height: min(58vw, 34rem);
+    background-position: center 22%;
+    background-size: cover;
+    opacity: 0.3;
+}
+
+.movie-details-backdrop::after {
+    position: absolute;
+    inset: 0;
+    content: "";
+    background:
+        linear-gradient(
+            90deg,
+            rgba(24, 27, 30, 0.96) 0%,
+            rgba(24, 27, 30, 0.72) 45%,
+            rgba(24, 27, 30, 0.38) 100%
+        ),
+        linear-gradient(
+            180deg,
+            transparent 25%,
+            #181b1e 100%
+        );
+}
+
+.movie-details-content {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(13rem, 19rem) minmax(0, 1fr);
+    gap: clamp(1.5rem, 5vw, 3.5rem);
+    align-items: start;
+    padding: clamp(1.25rem, 5vw, 3.5rem);
+}
+
+.movie-details-poster {
+    width: 100%;
+    aspect-ratio: 2 / 3;
+    object-fit: cover;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 0.85rem;
+    box-shadow: 0 1.2rem 2.4rem rgba(0, 0, 0, 0.42);
+}
+
+.movie-details-copy {
+    min-width: 0;
+    padding-top: clamp(0.5rem, 4vw, 2.5rem);
+}
+
+.movie-details-eyebrow {
+    margin: 0 0 0.55rem;
+    color: #ff718f;
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.movie-details-copy h1 {
+    max-width: 18ch;
+    margin: 0;
+    font-size: clamp(2.4rem, 7vw, 5rem);
+    line-height: 0.98;
+    letter-spacing: -0.035em;
+}
+
+.movie-details-tagline {
+    max-width: 42rem;
+    margin: 1rem 0 0;
+    color: #d3d6d9;
+    font-size: clamp(1rem, 2.2vw, 1.2rem);
+    font-style: italic;
+    line-height: 1.5;
+}
+
+.movie-details-facts,
+.movie-details-genres {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.movie-details-facts {
+    margin-top: 1.25rem;
+    color: #d3d6d9;
+}
+
+.movie-details-facts span,
+.movie-details-genres span {
+    display: inline-flex;
+    gap: 0.4rem;
+    align-items: center;
+    padding: 0.38rem 0.65rem;
+    background-color: rgba(255, 255, 255, 0.07);
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 999px;
+    font-size: 0.82rem;
+}
+
+.movie-details-genres {
+    margin-top: 0.75rem;
+}
+
+.movie-details-genres span {
+    color: #ffc0ce;
+    background-color: rgba(230, 30, 77, 0.12);
+    border-color: rgba(230, 30, 77, 0.28);
+}
+
+.movie-details-rating {
+    display: flex;
+    gap: 0.45rem;
+    align-items: baseline;
+    margin-top: 1.5rem;
+    color: #f5c518;
+}
+
+.movie-details-rating strong {
+    font-size: 1.5rem;
+}
+
+.movie-details-rating span {
+    color: #b8bdc2;
+    font-size: 0.85rem;
+}
+
+.movie-details-overview {
+    max-width: 48rem;
+    margin-top: 1.75rem;
+}
+
+.movie-details-overview h2 {
+    margin-bottom: 0.65rem;
+    font-size: 1.2rem;
+}
+
+.movie-details-overview p {
+    margin: 0;
+    color: #d3d6d9;
+    font-size: 1rem;
+    line-height: 1.7;
+}
+
+.movie-details-loading {
+    min-height: 24rem;
+    display: flex;
+    gap: 0.6rem;
+    align-items: center;
+    justify-content: center;
+    color: #d3d6d9;
+}
+
+.movie-details-error {
+    max-width: 42rem;
+    margin: 4rem auto;
+    padding: clamp(1.5rem, 5vw, 2.5rem);
+    text-align: center;
+    background-color: rgba(24, 27, 30, 0.92);
+    border: 1px solid rgba(230, 30, 77, 0.34);
+    border-radius: 1rem;
+    box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.28);
+}
+
+.movie-details-error p:not(.movie-details-eyebrow) {
+    color: #b8bdc2;
+}
+
+.movie-details-error a {
+    display: inline-flex;
+    margin-top: 0.5rem;
+    color: #ff8ca4;
+    font-weight: 750;
+}
+
+@media (max-width: 767.98px) {
+    .movie-details-content {
+        grid-template-columns: 1fr;
+    }
+
+    .movie-details-poster {
+        width: min(70vw, 17rem);
+    }
+
+    .movie-details-copy {
+        padding-top: 0;
+    }
+
+    .movie-details-copy h1 {
+        max-width: none;
+    }
+
+    .movie-details-backdrop {
+        height: 25rem;
+    }
+}
+
+@media (max-width: 575.98px) {
+    .movie-details-page {
+        padding-top: 0.75rem;
+    }
+
+    .movie-details-content {
+        padding: 1rem;
+    }
+
+    .movie-details-poster {
+        width: min(75vw, 15rem);
+    }
+}

--- a/Catacombs/client/src/components/Movies/MovieDetails.css
+++ b/Catacombs/client/src/components/Movies/MovieDetails.css
@@ -154,6 +154,66 @@
     border-color: rgba(230, 30, 77, 0.28);
 }
 
+.movie-details-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    margin-top: 1.5rem;
+}
+
+.movie-details-similar-action {
+    min-height: 2.7rem;
+    display: inline-flex;
+    gap: 0.5rem;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.85rem;
+    color: #e7e9eb;
+    background-color: #2d3338;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.65rem;
+    box-shadow: 0 0.25rem 0.65rem rgba(0, 0, 0, 0.18);
+    font-size: 0.9rem;
+    font-weight: 750;
+    text-decoration: none;
+    transition:
+        background-color 150ms ease,
+        border-color 150ms ease,
+        box-shadow 150ms ease,
+        color 150ms ease,
+        transform 150ms ease;
+}
+
+.movie-details-similar-action:hover,
+.movie-details-similar-action:focus-visible {
+    color: #ffffff;
+    background-color: #e61e4d;
+    border-color: #ff5579;
+    box-shadow: 0 0.4rem 0.9rem rgba(230, 30, 77, 0.28);
+    transform: translateY(-1px);
+}
+
+.movie-details-similar-action:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 0.2rem rgba(255, 85, 121, 0.35);
+}
+
+.movie-details-social {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    align-items: center;
+    margin-top: 1rem;
+}
+
+.movie-details-social > span {
+    color: #aeb4b9;
+    font-size: 0.78rem;
+    font-weight: 750;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
 .movie-details-rating {
     display: flex;
     gap: 0.45rem;
@@ -252,5 +312,15 @@
 
     .movie-details-poster {
         width: min(75vw, 15rem);
+    }
+
+    .movie-details-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .movie-details-actions .movie-icon-button--labeled.btn,
+    .movie-details-similar-action {
+        width: 100%;
     }
 }

--- a/Catacombs/client/src/components/Movies/MovieDetails.css
+++ b/Catacombs/client/src/components/Movies/MovieDetails.css
@@ -248,6 +248,113 @@
     line-height: 1.7;
 }
 
+.where-to-watch {
+    max-width: 48rem;
+    margin-top: 2rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.11);
+}
+
+.where-to-watch-heading {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.where-to-watch-heading h2 {
+    margin: 0;
+    font-size: 1.35rem;
+}
+
+.where-to-watch-heading .movie-details-eyebrow {
+    margin-bottom: 0.35rem;
+}
+
+.where-to-watch-heading > a {
+    flex-shrink: 0;
+    color: #ff8ca4;
+    font-size: 0.84rem;
+    font-weight: 750;
+    text-decoration: none;
+}
+
+.where-to-watch-heading > a:hover,
+.where-to-watch-heading > a:focus-visible,
+.where-to-watch-credit a:hover,
+.where-to-watch-credit a:focus-visible {
+    color: #ffffff;
+    text-decoration: underline;
+}
+
+.where-to-watch-groups {
+    display: grid;
+    gap: 1rem;
+    margin-top: 1.15rem;
+}
+
+.where-to-watch-group {
+    display: grid;
+    grid-template-columns: 4.5rem minmax(0, 1fr);
+    gap: 0.9rem;
+    align-items: start;
+}
+
+.where-to-watch-group h3 {
+    margin: 0.65rem 0 0;
+    color: #c9cdd1;
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+}
+
+.where-to-watch-providers {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.7rem;
+}
+
+.where-to-watch-provider {
+    width: 5.25rem;
+    display: flex;
+    gap: 0.45rem;
+    align-items: center;
+    flex-direction: column;
+    color: #d3d6d9;
+    font-size: 0.72rem;
+    line-height: 1.25;
+    text-align: center;
+}
+
+.where-to-watch-provider img {
+    width: 3.5rem;
+    height: 3.5rem;
+    object-fit: cover;
+    border: 1px solid rgba(255, 255, 255, 0.14);
+    border-radius: 0.75rem;
+    box-shadow: 0 0.45rem 0.9rem rgba(0, 0, 0, 0.24);
+}
+
+.where-to-watch-empty {
+    margin: 1rem 0 0;
+    padding: 0.9rem 1rem;
+    color: #b8bdc2;
+    background-color: rgba(255, 255, 255, 0.045);
+    border: 1px solid rgba(255, 255, 255, 0.09);
+    border-radius: 0.7rem;
+}
+
+.where-to-watch-credit {
+    margin: 1rem 0 0;
+    color: #8f969c;
+    font-size: 0.72rem;
+}
+
+.where-to-watch-credit a {
+    color: #b8bdc2;
+}
+
 .movie-details-loading {
     min-height: 24rem;
     display: flex;
@@ -322,5 +429,19 @@
     .movie-details-actions .movie-icon-button--labeled.btn,
     .movie-details-similar-action {
         width: 100%;
+    }
+
+    .where-to-watch-heading {
+        align-items: flex-start;
+        flex-direction: column;
+    }
+
+    .where-to-watch-group {
+        grid-template-columns: 1fr;
+        gap: 0.45rem;
+    }
+
+    .where-to-watch-group h3 {
+        margin-top: 0;
     }
 }

--- a/Catacombs/client/src/components/Movies/MovieDetails.js
+++ b/Catacombs/client/src/components/Movies/MovieDetails.js
@@ -1,0 +1,245 @@
+import React, { useContext, useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+    faArrowLeft,
+    faClock,
+    faStar
+} from "@fortawesome/free-solid-svg-icons";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { Container, Spinner } from "reactstrap";
+import { MovieContext } from "../Repositories/MovieProvider";
+import { getMoviePosterUrl } from "./MovieCardContent";
+import "./MovieDetails.css";
+
+const backdropBaseUrl = "https://image.tmdb.org/t/p/w1280";
+
+const getBackdropUrl = (backdropPath) => (
+    backdropPath ? `${backdropBaseUrl}${backdropPath}` : null
+);
+
+const formatReleaseDate = (releaseDate) => {
+    const parts = releaseDate?.split("-").map(Number);
+
+    if (
+        !parts ||
+        parts.length !== 3 ||
+        parts.some((part) => !Number.isInteger(part))
+    ) {
+        return "Release date unavailable";
+    }
+
+    return new Date(
+        parts[0],
+        parts[1] - 1,
+        parts[2]
+    ).toLocaleDateString(
+        "en-US",
+        {
+            year: "numeric",
+            month: "long",
+            day: "numeric"
+        }
+    );
+};
+
+const formatRuntime = (runtime) => {
+    if (!Number.isInteger(runtime) || runtime <= 0) {
+        return "Runtime unavailable";
+    }
+
+    const hours = Math.floor(runtime / 60);
+    const minutes = runtime % 60;
+
+    if (hours === 0) {
+        return `${minutes}m`;
+    }
+
+    return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+};
+
+export const MovieDetails = () => {
+    const { id } = useParams();
+    const navigate = useNavigate();
+    const { getMovieDetails } = useContext(MovieContext);
+    const [movie, setMovie] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [loadError, setLoadError] = useState("");
+
+    useEffect(() => {
+        let isCancelled = false;
+        const movieId = Number(id);
+
+        if (!Number.isInteger(movieId) || movieId <= 0) {
+            setLoadError("That movie could not be found.");
+            setIsLoading(false);
+            return () => {
+                isCancelled = true;
+            };
+        }
+
+        setIsLoading(true);
+        setLoadError("");
+
+        getMovieDetails(movieId)
+            .then((movieDetails) => {
+                if (!isCancelled) {
+                    setMovie(movieDetails);
+                }
+            })
+            .catch((error) => {
+                if (!isCancelled) {
+                    setLoadError(error.message);
+                }
+            })
+            .finally(() => {
+                if (!isCancelled) {
+                    setIsLoading(false);
+                }
+            });
+
+        return () => {
+            isCancelled = true;
+        };
+    }, [getMovieDetails, id]);
+
+    const handleBack = () => {
+        navigate(-1);
+    };
+
+    const backdropUrl = getBackdropUrl(movie?.backdrop_path);
+    const genres = movie?.genres?.map((genre) => genre.name) || [];
+    const rating = Number(movie?.vote_average);
+
+    return (
+        <main className="movie-details-page">
+            <Container>
+                <button
+                    type="button"
+                    className="movie-details-back"
+                    onClick={handleBack}
+                >
+                    <FontAwesomeIcon
+                        icon={faArrowLeft}
+                        aria-hidden="true"
+                    />
+                    Back to movies
+                </button>
+
+                {isLoading ? (
+                    <div
+                        className="movie-details-loading"
+                        role="status"
+                        aria-live="polite"
+                    >
+                        <Spinner size="sm" aria-hidden="true" />
+                        <span>Unearthing movie details...</span>
+                    </div>
+                ) : loadError || !movie ? (
+                    <section className="movie-details-error" role="alert">
+                        <p className="movie-details-eyebrow">
+                            The trail goes cold
+                        </p>
+                        <h1>Movie details unavailable</h1>
+                        <p>
+                            {loadError ||
+                                "The movie service did not return this title."}
+                        </p>
+                        <Link to="/movies/popular">
+                            Return to popular movies
+                        </Link>
+                    </section>
+                ) : (
+                    <article className="movie-details-card">
+                        {backdropUrl && (
+                            <div
+                                className="movie-details-backdrop"
+                                style={{
+                                    backgroundImage: `url(${backdropUrl})`
+                                }}
+                                aria-hidden="true"
+                            />
+                        )}
+                        <div className="movie-details-content">
+                            <img
+                                className="movie-details-poster"
+                                src={getMoviePosterUrl(movie.poster_path)}
+                                alt={`${movie.title} poster`}
+                            />
+                            <div className="movie-details-copy">
+                                <p className="movie-details-eyebrow">
+                                    Movie details
+                                </p>
+                                <h1>{movie.title}</h1>
+                                {movie.tagline && (
+                                    <p className="movie-details-tagline">
+                                        {movie.tagline}
+                                    </p>
+                                )}
+
+                                <div
+                                    className="movie-details-facts"
+                                    aria-label="Movie facts"
+                                >
+                                    <span>
+                                        {formatReleaseDate(
+                                            movie.release_date
+                                        )}
+                                    </span>
+                                    <span>
+                                        <FontAwesomeIcon
+                                            icon={faClock}
+                                            aria-hidden="true"
+                                        />
+                                        {formatRuntime(movie.runtime)}
+                                    </span>
+                                    {movie.status && (
+                                        <span>{movie.status}</span>
+                                    )}
+                                </div>
+
+                                {genres.length > 0 && (
+                                    <div
+                                        className="movie-details-genres"
+                                        aria-label="Genres"
+                                    >
+                                        {genres.map((genre) => (
+                                            <span key={genre}>{genre}</span>
+                                        ))}
+                                    </div>
+                                )}
+
+                                <div className="movie-details-rating">
+                                    <FontAwesomeIcon
+                                        icon={faStar}
+                                        aria-hidden="true"
+                                    />
+                                    <strong>
+                                        {Number.isFinite(rating) && rating > 0
+                                            ? rating.toFixed(1)
+                                            : "Not rated"}
+                                    </strong>
+                                    {Number.isFinite(rating) && rating > 0 && (
+                                        <span>/ 10 TMDB rating</span>
+                                    )}
+                                </div>
+
+                                <section
+                                    className="movie-details-overview"
+                                    aria-labelledby="movie-overview-heading"
+                                >
+                                    <h2 id="movie-overview-heading">
+                                        Overview
+                                    </h2>
+                                    <p>
+                                        {movie.overview ||
+                                            "No overview is available for this movie."}
+                                    </p>
+                                </section>
+                            </div>
+                        </div>
+                    </article>
+                )}
+            </Container>
+        </main>
+    );
+};

--- a/Catacombs/client/src/components/Movies/MovieDetails.js
+++ b/Catacombs/client/src/components/Movies/MovieDetails.js
@@ -14,6 +14,7 @@ import { MovieCollectionActions } from "./MovieCollectionActions";
 import { SocialLinks } from "./SocialLinks";
 import { TrailerButton } from "./TrailerButton";
 import { selectTrailer } from "./useMovieMetadata";
+import { WhereToWatch } from "./WhereToWatch";
 import "./Movie.css";
 import "./MovieDetails.css";
 
@@ -275,6 +276,13 @@ export const MovieDetails = () => {
                                             "No overview is available for this movie."}
                                     </p>
                                 </section>
+
+                                <WhereToWatch
+                                    movieTitle={movie.title}
+                                    watchProviders={
+                                        movie["watch/providers"]
+                                    }
+                                />
                             </div>
                         </div>
                     </article>

--- a/Catacombs/client/src/components/Movies/MovieDetails.js
+++ b/Catacombs/client/src/components/Movies/MovieDetails.js
@@ -2,6 +2,7 @@ import React, { useContext, useEffect, useState } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
     faArrowLeft,
+    faClapperboard,
     faClock,
     faStar
 } from "@fortawesome/free-solid-svg-icons";
@@ -9,6 +10,11 @@ import { Link, useNavigate, useParams } from "react-router-dom";
 import { Container, Spinner } from "reactstrap";
 import { MovieContext } from "../Repositories/MovieProvider";
 import { getMoviePosterUrl } from "./MovieCardContent";
+import { MovieCollectionActions } from "./MovieCollectionActions";
+import { SocialLinks } from "./SocialLinks";
+import { TrailerButton } from "./TrailerButton";
+import { selectTrailer } from "./useMovieMetadata";
+import "./Movie.css";
 import "./MovieDetails.css";
 
 const backdropBaseUrl = "https://image.tmdb.org/t/p/w1280";
@@ -109,6 +115,7 @@ export const MovieDetails = () => {
     const backdropUrl = getBackdropUrl(movie?.backdrop_path);
     const genres = movie?.genres?.map((genre) => genre.name) || [];
     const rating = Number(movie?.vote_average);
+    const trailer = selectTrailer(movie?.videos);
 
     return (
         <main className="movie-details-page">
@@ -207,6 +214,39 @@ export const MovieDetails = () => {
                                         ))}
                                     </div>
                                 )}
+
+                                <div
+                                    className="movie-details-actions"
+                                    role="group"
+                                    aria-label={`Actions for ${movie.title}`}
+                                >
+                                    <TrailerButton
+                                        trailer={trailer}
+                                        title={movie.title}
+                                        showLabel
+                                    />
+                                    <MovieCollectionActions
+                                        movie={movie}
+                                        showLabels
+                                    />
+                                    <Link
+                                        className="movie-details-similar-action"
+                                        to={`/movies/similar/${movie.id}`}
+                                    >
+                                        <FontAwesomeIcon
+                                            icon={faClapperboard}
+                                            aria-hidden="true"
+                                        />
+                                        Similar movies
+                                    </Link>
+                                </div>
+
+                                <div className="movie-details-social">
+                                    <span>Find this movie elsewhere</span>
+                                    <SocialLinks
+                                        socials={movie.external_ids || {}}
+                                    />
+                                </div>
 
                                 <div className="movie-details-rating">
                                     <FontAwesomeIcon

--- a/Catacombs/client/src/components/Movies/TrailerButton.js
+++ b/Catacombs/client/src/components/Movies/TrailerButton.js
@@ -7,7 +7,11 @@ import {
 } from "reactstrap";
 import { MovieActionButton } from "./MovieActionButton";
 
-export const TrailerButton = ({ trailer, title }) => {
+export const TrailerButton = ({
+    trailer,
+    title,
+    showLabel = false
+}) => {
     const [isOpen, setIsOpen] = useState(false);
 
     if (!trailer) {
@@ -26,6 +30,7 @@ export const TrailerButton = ({ trailer, title }) => {
                 label={`Watch the trailer for ${title}`}
                 onClick={toggle}
                 variant="trailer"
+                text={showLabel ? "Watch trailer" : undefined}
             />
             <Modal
                 isOpen={isOpen}

--- a/Catacombs/client/src/components/Movies/WhereToWatch.js
+++ b/Catacombs/client/src/components/Movies/WhereToWatch.js
@@ -1,0 +1,119 @@
+import React from "react";
+
+const providerLogoBaseUrl = "https://image.tmdb.org/t/p/w92";
+
+const uniqueProviders = (...providerLists) => {
+    const providersById = new Map();
+
+    providerLists.flat().forEach((provider) => {
+        if (provider?.provider_id) {
+            providersById.set(provider.provider_id, provider);
+        }
+    });
+
+    return Array.from(providersById.values());
+};
+
+const ProviderList = ({ providers }) => (
+    <div className="where-to-watch-providers">
+        {providers.map((provider) => (
+            <div
+                className="where-to-watch-provider"
+                key={provider.provider_id}
+                title={provider.provider_name}
+            >
+                {provider.logo_path && (
+                    <img
+                        src={`${providerLogoBaseUrl}${provider.logo_path}`}
+                        alt=""
+                        aria-hidden="true"
+                    />
+                )}
+                <span>{provider.provider_name}</span>
+            </div>
+        ))}
+    </div>
+);
+
+export const WhereToWatch = ({ movieTitle, watchProviders }) => {
+    const availability = watchProviders?.results?.US;
+    const groups = availability ? [
+        {
+            key: "stream",
+            title: "Stream",
+            providers: uniqueProviders(availability.flatrate || [])
+        },
+        {
+            key: "free",
+            title: "Free",
+            providers: uniqueProviders(
+                availability.free || [],
+                availability.ads || []
+            )
+        },
+        {
+            key: "rent",
+            title: "Rent",
+            providers: uniqueProviders(availability.rent || [])
+        },
+        {
+            key: "buy",
+            title: "Buy",
+            providers: uniqueProviders(availability.buy || [])
+        }
+    ].filter((group) => group.providers.length > 0) : [];
+
+    return (
+        <section
+            className="where-to-watch"
+            aria-labelledby="where-to-watch-heading"
+        >
+            <div className="where-to-watch-heading">
+                <div>
+                    <p className="movie-details-eyebrow">Available in the U.S.</p>
+                    <h2 id="where-to-watch-heading">Where to Watch</h2>
+                </div>
+                {availability?.link && (
+                    <a
+                        href={availability.link}
+                        target="_blank"
+                        rel="noreferrer"
+                    >
+                        View current options
+                    </a>
+                )}
+            </div>
+
+            {groups.length > 0 ? (
+                <div className="where-to-watch-groups">
+                    {groups.map((group) => (
+                        <div
+                            className="where-to-watch-group"
+                            key={group.key}
+                        >
+                            <h3>{group.title}</h3>
+                            <ProviderList providers={group.providers} />
+                        </div>
+                    ))}
+                </div>
+            ) : (
+                <p className="where-to-watch-empty">
+                    No U.S. streaming, rental, or purchase listings are
+                    currently available for {movieTitle}.
+                </p>
+            )}
+
+            <p className="where-to-watch-credit">
+                Availability data provided by{" "}
+                <a
+                    href="https://www.justwatch.com/"
+                    target="_blank"
+                    rel="noreferrer"
+                >
+                    JustWatch
+                </a>
+                . Listings may change.
+            </p>
+        </section>
+    );
+};

--- a/Catacombs/client/src/components/Movies/useMovieMetadata.js
+++ b/Catacombs/client/src/components/Movies/useMovieMetadata.js
@@ -8,7 +8,7 @@ const emptyMetadata = {
     }
 };
 
-const selectTrailer = (videos) => {
+export const selectTrailer = (videos) => {
     return (videos?.results || [])
         .filter(video =>
             video.site === "YouTube" &&

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -1,4 +1,9 @@
-import React, { useMemo, useState, createContext } from "react"
+import React, {
+    useCallback,
+    useMemo,
+    useState,
+    createContext
+} from "react"
 
 export const MovieContext = createContext()
 
@@ -88,14 +93,14 @@ export const MovieProvider = (props) => {
         return savedMovie
     }
 
-    const loadMovieCollection = () => {
+    const loadMovieCollection = useCallback(() => {
         return apiFetch("/api/Movies/collection")
             .then((response) => response.json())
             .then((collection) => {
                 setSavedMovies(collection)
                 return collection
             })
-    }
+    }, [])
 
     const loadTmdbMovies = async (path) => {
         setIsLoadingMovies(true)
@@ -180,11 +185,13 @@ export const MovieProvider = (props) => {
         }))
     }
 
-    const getMovieDetails = (movieId) => {
-        return tmdbApiFetch(
-            `/api/tmdb/movies/${movieId}/metadata`
-        )
-    }
+    const getMovieDetails = useCallback(async (movieId) => {
+        const [details] = await Promise.all([
+            tmdbApiFetch(`/api/tmdb/movies/${movieId}/metadata`),
+            loadMovieCollection()
+        ])
+        return details
+    }, [loadMovieCollection])
 
     const addMovie = async (movie) => {
         const response = await secureApiFetch("/api/Movies", {

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -180,6 +180,12 @@ export const MovieProvider = (props) => {
         }))
     }
 
+    const getMovieDetails = (movieId) => {
+        return tmdbApiFetch(
+            `/api/tmdb/movies/${movieId}/metadata`
+        )
+    }
+
     const addMovie = async (movie) => {
         const response = await secureApiFetch("/api/Movies", {
             method: "POST",
@@ -285,6 +291,7 @@ export const MovieProvider = (props) => {
             deleteMovie,
             getAllLikedMovies,
             getAllDislikedMovies,
+            getMovieDetails,
             getMovieSummary,
             getMovieMetadata
         }}>


### PR DESCRIPTION
## Description

This PR adds a full movie details page so users can learn more about a movie and manage it without going back to the movie lists. It also shows where the movie is currently available to stream, rent, or buy in the United States.

## Changes

- Added a movie details page with the poster, backdrop, release date, runtime, genres, rating, tagline, and overview
- Made movie posters and titles open the new details page
- Added trailer, watchlist, watched, and rating actions
- Added links for similar movies and available social pages
- Added U.S. streaming, free, rental, and purchase options
- Added provider logos and JustWatch attribution
- Added loading, error, and unavailable-provider messages
- Fixed an issue that caused movie details to load continuously

## Testing

- The frontend builds successfully
- All 24 backend tests pass
- Movie details load correctly
- Movie actions and navigation work correctly
- Where-to-watch providers display correctly