### PR TITLE
Improve movie search and add pagination

### DIFF
--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -457,6 +457,31 @@
     text-align: center;
 }
 
+.movie-search-result-count {
+    margin: 0.55rem 0 0;
+    color: #aeb4b9;
+    font-size: 0.85rem;
+}
+
+.movie-search-clear-button.btn {
+    margin-top: 0.9rem;
+    padding: 0.42rem 0.7rem;
+    color: #c9cdd1;
+    background-color: transparent;
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    border-radius: 0.55rem;
+    font-size: 0.78rem;
+    font-weight: 750;
+}
+
+.movie-search-clear-button.btn:hover,
+.movie-search-clear-button.btn:focus-visible {
+    color: #ffffff;
+    background-color: rgba(230, 30, 77, 0.15);
+    border-color: rgba(255, 113, 143, 0.55);
+    box-shadow: none;
+}
+
 @media (max-width: 575.98px) {
     .movie-search-form {
         flex-direction: column;

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -454,6 +454,7 @@
 
 .movie-search-results-heading {
     margin: 0 auto;
+    scroll-margin-top: 6rem;
     text-align: center;
 }
 

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -417,6 +417,46 @@
     transform: none;
 }
 
+.movie-search-idle-state {
+    max-width: 38rem;
+    margin: 0 auto 3rem;
+    padding: clamp(1.5rem, 5vw, 2.25rem);
+    text-align: center;
+    background:
+        radial-gradient(
+            circle at top,
+            rgba(230, 30, 77, 0.09),
+            transparent 65%
+        ),
+        rgba(24, 27, 30, 0.72);
+    border: 1px dashed rgba(255, 113, 143, 0.3);
+    border-radius: 1rem;
+}
+
+.movie-search-state-eyebrow {
+    margin: 0 0 0.45rem;
+    color: #ff718f;
+    font-size: 0.72rem;
+    font-weight: 800;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.movie-search-idle-state h2,
+.movie-search-results-heading h2 {
+    margin: 0;
+}
+
+.movie-search-idle-state > p:last-child {
+    margin: 0.75rem 0 0;
+    color: #b8bdc2;
+}
+
+.movie-search-results-heading {
+    margin: 0 auto;
+    text-align: center;
+}
+
 @media (max-width: 575.98px) {
     .movie-search-form {
         flex-direction: column;

--- a/Catacombs/client/src/components/Movies/MoviePagination.js
+++ b/Catacombs/client/src/components/Movies/MoviePagination.js
@@ -24,6 +24,7 @@ const visiblePageNumbers = (currentPage, totalPages) => {
 
 export const MoviePagination = ({
     basePath,
+    getPagePath,
     currentPage,
     totalPages
 }) => {
@@ -33,9 +34,9 @@ export const MoviePagination = ({
         return null;
     }
 
-    const pagePath = (page) => (
+    const pagePath = getPagePath || ((page) => (
         page === 1 ? basePath : `${basePath}/${page}`
-    );
+    ));
     const pageNumbers = visiblePageNumbers(currentPage, lastPage);
     const showFirstPage = pageNumbers[0] > 1;
     const showLastPage =

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -1,15 +1,30 @@
 import React, { useContext, useEffect, useState } from "react";
+import { useSearchParams } from "react-router-dom";
 import { MovieContext } from "../Repositories/MovieProvider"
 import { MovieCard } from "./MovieCard";
+import { MoviePagination } from "./MoviePagination";
 import { Alert, Container, Button, Spinner } from "reactstrap";
 import "./Movie.css"
 
 export const SearchMovies = () => {
-    const [searchTerm, setSearchTerm] = useState("")
-    const [submittedSearchTerm, setSubmittedSearchTerm] = useState("")
-    const [hasSearched, setHasSearched] = useState(false)
+    const [searchParams, setSearchParams] = useSearchParams()
+    const submittedSearchTerm =
+        (searchParams.get("query") || "").trim()
+    const parsedPage = Number(searchParams.get("page") || "1")
+    const requestedPage =
+        Number.isInteger(parsedPage) &&
+        parsedPage >= 1 &&
+        parsedPage <= 500
+            ? parsedPage
+            : 1
+    const searchKey = submittedSearchTerm
+        ? `${submittedSearchTerm}:${requestedPage}`
+        : ""
+    const [searchTerm, setSearchTerm] = useState(submittedSearchTerm)
+    const [completedSearchKey, setCompletedSearchKey] = useState("")
     const {
         movies,
+        moviePage,
         searchMovies,
         clearMovieResults,
         isLoadingMovies,
@@ -17,31 +32,92 @@ export const SearchMovies = () => {
     } = useContext(MovieContext);
 
     useEffect(() => {
-        clearMovieResults()
-    }, [clearMovieResults])
+        let isActive = true
 
-    const handleSearch = async (event) => {
+        setSearchTerm(submittedSearchTerm)
+        setCompletedSearchKey("")
+
+        if (!submittedSearchTerm) {
+            clearMovieResults()
+            return () => {
+                isActive = false
+            }
+        }
+
+        searchMovies(submittedSearchTerm, requestedPage)
+            .finally(() => {
+                if (isActive) {
+                    setCompletedSearchKey(searchKey)
+                }
+            })
+
+        return () => {
+            isActive = false
+        }
+        // searchMovies is supplied by MovieProvider and intentionally omitted.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        clearMovieResults,
+        requestedPage,
+        searchKey,
+        submittedSearchTerm
+    ])
+
+    const handleSearch = (event) => {
         event?.preventDefault()
         const query = searchTerm.trim()
         if (!query) {
             return
         }
 
-        setHasSearched(true)
-        setSubmittedSearchTerm(query)
-        await searchMovies(query)
+        setSearchParams({ query })
     }
 
+    const clearSearch = () => {
+        setSearchTerm("")
+        setSearchParams({})
+    }
+
+    const hasSearched = Boolean(submittedSearchTerm)
+    const isCurrentSearchComplete =
+        completedSearchKey === searchKey
     const noResults =
         hasSearched &&
+        isCurrentSearchComplete &&
         !isLoadingMovies &&
         !movieLoadError &&
         movies.length === 0;
     const hasResults =
         hasSearched &&
+        isCurrentSearchComplete &&
         !isLoadingMovies &&
         !movieLoadError &&
         movies.length > 0;
+    const totalPages = moviePage.totalPages
+    const currentPage = Math.min(
+        moviePage.page || requestedPage,
+        Math.max(totalPages, 1),
+        500
+    )
+    const resultCount = moviePage.totalResults || movies.length
+    const pagePath = (page) => {
+        const parameters = new URLSearchParams({
+            query: submittedSearchTerm
+        })
+
+        if (page > 1) {
+            parameters.set("page", String(page))
+        }
+
+        return `/movies/search?${parameters.toString()}`
+    }
+    const pagination = hasResults ? (
+        <MoviePagination
+            getPagePath={pagePath}
+            currentPage={currentPage}
+            totalPages={totalPages}
+        />
+    ) : null
 
     return (
         <>
@@ -135,6 +211,13 @@ export const SearchMovies = () => {
                                 &ldquo;{submittedSearchTerm}&rdquo;. Check the
                                 spelling or try another title.
                             </p>
+                            <Button
+                                type="button"
+                                className="movie-search-clear-button"
+                                onClick={clearSearch}
+                            >
+                                Clear search
+                            </Button>
                         </section>
                     )}
                     {isLoadingMovies && (
@@ -153,8 +236,25 @@ export const SearchMovies = () => {
                                 <p className="movie-search-state-eyebrow">
                                     Titles unearthed
                                 </p>
-                                <h2>Search Results</h2>
+                                <h2>
+                                    Results for &ldquo;
+                                    {submittedSearchTerm}
+                                    &rdquo;
+                                </h2>
+                                <p className="movie-search-result-count">
+                                    {resultCount.toLocaleString()}{" "}
+                                    {resultCount === 1 ? "title" : "titles"}{" "}
+                                    found
+                                </p>
+                                <Button
+                                    type="button"
+                                    className="movie-search-clear-button"
+                                    onClick={clearSearch}
+                                >
+                                    Clear search
+                                </Button>
                             </header>
+                            {pagination}
                             <div className="discovery-movie-grid">
                                 {movies.map(movie => (
                                     <MovieCard
@@ -163,6 +263,7 @@ export const SearchMovies = () => {
                                     />
                                 ))}
                             </div>
+                            {pagination}
                         </>
                     )}
                 </Container>

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -1,4 +1,9 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, {
+    useContext,
+    useEffect,
+    useRef,
+    useState
+} from "react";
 import { useSearchParams } from "react-router-dom";
 import { MovieContext } from "../Repositories/MovieProvider"
 import { MovieCard } from "./MovieCard";
@@ -22,6 +27,8 @@ export const SearchMovies = () => {
         : ""
     const [searchTerm, setSearchTerm] = useState(submittedSearchTerm)
     const [completedSearchKey, setCompletedSearchKey] = useState("")
+    const resultsHeadingRef = useRef(null)
+    const previousPageRef = useRef(requestedPage)
     const {
         movies,
         moviePage,
@@ -118,6 +125,28 @@ export const SearchMovies = () => {
             totalPages={totalPages}
         />
     ) : null
+
+    useEffect(() => {
+        if (!hasResults) {
+            return
+        }
+
+        const pageChanged = previousPageRef.current !== requestedPage
+        previousPageRef.current = requestedPage
+
+        if (!pageChanged) {
+            return
+        }
+
+        const reduceMotion = window.matchMedia?.(
+            "(prefers-reduced-motion: reduce)"
+        ).matches
+
+        resultsHeadingRef.current?.scrollIntoView({
+            behavior: reduceMotion ? "auto" : "smooth",
+            block: "start"
+        })
+    }, [hasResults, requestedPage])
 
     return (
         <>
@@ -232,7 +261,10 @@ export const SearchMovies = () => {
                     )}
                     {hasResults && (
                         <>
-                            <header className="movie-search-results-heading">
+                            <header
+                                className="movie-search-results-heading"
+                                ref={resultsHeadingRef}
+                            >
                                 <p className="movie-search-state-eyebrow">
                                     Titles unearthed
                                 </p>

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { MovieContext } from "../Repositories/MovieProvider"
 import { MovieCard } from "./MovieCard";
 import { Alert, Container, Button, Spinner } from "reactstrap";
@@ -6,13 +6,19 @@ import "./Movie.css"
 
 export const SearchMovies = () => {
     const [searchTerm, setSearchTerm] = useState("")
+    const [submittedSearchTerm, setSubmittedSearchTerm] = useState("")
     const [hasSearched, setHasSearched] = useState(false)
     const {
         movies,
         searchMovies,
+        clearMovieResults,
         isLoadingMovies,
         movieLoadError
     } = useContext(MovieContext);
+
+    useEffect(() => {
+        clearMovieResults()
+    }, [clearMovieResults])
 
     const handleSearch = async (event) => {
         event?.preventDefault()
@@ -22,6 +28,7 @@ export const SearchMovies = () => {
         }
 
         setHasSearched(true)
+        setSubmittedSearchTerm(query)
         await searchMovies(query)
     }
 
@@ -30,6 +37,11 @@ export const SearchMovies = () => {
         !isLoadingMovies &&
         !movieLoadError &&
         movies.length === 0;
+    const hasResults =
+        hasSearched &&
+        !isLoadingMovies &&
+        !movieLoadError &&
+        movies.length > 0;
 
     return (
         <>
@@ -85,14 +97,47 @@ export const SearchMovies = () => {
                     </section>
                 </Container>
                 <Container>
-                    <h1 style={{ textAlign: "center" }}>Search Results</h1>
                     {movieLoadError && (
                         <Alert color="danger" role="alert">
                             {movieLoadError}
                         </Alert>
                     )}
-                    {noResults && <h4>Nothing Found</h4>}
-                    {isLoadingMovies ? (
+                    {!hasSearched && (
+                        <section
+                            className="movie-search-idle-state"
+                            aria-labelledby="movie-search-idle-heading"
+                        >
+                            <p className="movie-search-state-eyebrow">
+                                The archive awaits
+                            </p>
+                            <h2 id="movie-search-idle-heading">
+                                Unearth a movie
+                            </h2>
+                            <p>
+                                Enter a title above to search the horror
+                                archives.
+                            </p>
+                        </section>
+                    )}
+                    {noResults && (
+                        <section
+                            className="movie-empty-state"
+                            aria-labelledby="movie-search-empty-heading"
+                        >
+                            <p className="movie-empty-state-eyebrow">
+                                The trail goes cold
+                            </p>
+                            <h2 id="movie-search-empty-heading">
+                                No movies found
+                            </h2>
+                            <p>
+                                We couldn&apos;t find a movie matching
+                                &ldquo;{submittedSearchTerm}&rdquo;. Check the
+                                spelling or try another title.
+                            </p>
+                        </section>
+                    )}
+                    {isLoadingMovies && (
                         <div
                             className="movie-loading"
                             role="status"
@@ -101,15 +146,24 @@ export const SearchMovies = () => {
                             <Spinner size="sm" aria-hidden="true" />
                             <span>Searching movies...</span>
                         </div>
-                    ) : (
-                        <div className="discovery-movie-grid">
-                            {movies.map(movie => (
-                                <MovieCard
-                                    key={movie.id}
-                                    movie={movie}
-                                />
-                            ))}
-                        </div>
+                    )}
+                    {hasResults && (
+                        <>
+                            <header className="movie-search-results-heading">
+                                <p className="movie-search-state-eyebrow">
+                                    Titles unearthed
+                                </p>
+                                <h2>Search Results</h2>
+                            </header>
+                            <div className="discovery-movie-grid">
+                                {movies.map(movie => (
+                                    <MovieCard
+                                        key={movie.id}
+                                        movie={movie}
+                                    />
+                                ))}
+                            </div>
+                        </>
                     )}
                 </Container>
             </div>

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -102,6 +102,13 @@ export const MovieProvider = (props) => {
             })
     }, [])
 
+    const clearMovieResults = useCallback(() => {
+        setMovies([])
+        setMoviePage(emptyMoviePage)
+        setMovieLoadError("")
+        setIsLoadingMovies(false)
+    }, [])
+
     const loadTmdbMovies = async (path) => {
         setIsLoadingMovies(true)
         setMovieLoadError("")
@@ -286,6 +293,7 @@ export const MovieProvider = (props) => {
             getMoviesByRating,
             popularMovies,
             hiddenGems,
+            clearMovieResults,
             addMovie,
             setMovieStatus,
             getWatchlist,


### PR DESCRIPTION
## Description

This PR improves the movie search page so it starts clean, only shows results from the current search, and supports multiple pages of results.

## Changes

- Cleared movies left over from other lists when opening Search
- Added a themed starting message before a search is submitted
- Hid the Search Results heading until results are available
- Added a themed message when no movies are found
- Added pagination above and below search results
- Stored the search title and current page in the URL
- Added support for refreshing and using browser Back and Forward
- Added the total number of matching titles
- Added a Clear Search button
- Added automatic scrolling to the results heading when changing pages
- Kept the existing pagination behavior unchanged on the other movie lists

## Testing

- The frontend builds successfully
- Search opens without showing movies from another list
- Search results display for the submitted title
- Pagination loads the correct result pages
- Clear Search returns to the clean starting state
- Search URLs restore correctly after refreshing
- Changing pages returns to the top of the results