### PR TITLE
Add release-year search and filtered horror browsing

### DIFF
--- a/Catacombs.Tests/TmdbClientTests.cs
+++ b/Catacombs.Tests/TmdbClientTests.cs
@@ -196,12 +196,32 @@ public sealed class TmdbClientTests
         await client.SearchMoviesAsync(
             "Alien & Aliens",
             2,
+            null,
             CancellationToken.None);
 
         Assert.Equal(
             "/3/search/movie?query=Alien%20%26%20Aliens" +
             "&include_adult=false&language=en-US&region=US&page=2",
             handler.RequestUri?.PathAndQuery);
+    }
+
+    [Fact]
+    public async Task SearchCanFilterByPrimaryReleaseYear()
+    {
+        var handler = new RecordingHandler();
+        var client = CreateClient(handler, TestToken);
+
+        await client.SearchMoviesAsync(
+            "Alien",
+            1,
+            1979,
+            CancellationToken.None);
+
+        var query = Uri.UnescapeDataString(
+            handler.RequestUri?.Query ?? string.Empty);
+
+        Assert.Contains("query=Alien", query);
+        Assert.Contains("primary_release_year=1979", query);
     }
 
     [Fact]

--- a/Catacombs.Tests/TmdbClientTests.cs
+++ b/Catacombs.Tests/TmdbClientTests.cs
@@ -225,6 +225,73 @@ public sealed class TmdbClientTests
     }
 
     [Fact]
+    public async Task BrowseHorrorAppliesFiltersBeforePagination()
+    {
+        var handler = new RecordingHandler();
+        var client = CreateClient(
+            handler,
+            TestToken,
+            new FixedTimeProvider(
+                new DateTimeOffset(
+                    2026,
+                    8,
+                    4,
+                    12,
+                    0,
+                    0,
+                    TimeSpan.Zero)));
+
+        await client.BrowseHorrorMoviesAsync(
+            3,
+            1980,
+            6.5,
+            250,
+            TmdbMovieSort.HighestRated,
+            CancellationToken.None);
+
+        var query = Uri.UnescapeDataString(
+            handler.RequestUri?.Query ?? string.Empty);
+
+        Assert.Equal(
+            "/3/discover/movie",
+            handler.RequestUri?.AbsolutePath);
+        Assert.Contains("page=3", query);
+        Assert.Contains("with_genres=27", query);
+        Assert.Contains("without_genres=10751,10770", query);
+        Assert.Contains("primary_release_date.gte=1980-01-01", query);
+        Assert.Contains("primary_release_date.lte=1989-12-31", query);
+        Assert.Contains("vote_average.gte=6.5", query);
+        Assert.Contains("vote_count.gte=250", query);
+        Assert.Contains("sort_by=vote_average.desc", query);
+    }
+
+    [Theory]
+    [InlineData(TmdbMovieSort.Popular, "popularity.desc")]
+    [InlineData(TmdbMovieSort.HighestRated, "vote_average.desc")]
+    [InlineData(TmdbMovieSort.Newest, "primary_release_date.desc")]
+    [InlineData(TmdbMovieSort.Oldest, "primary_release_date.asc")]
+    public async Task BrowseHorrorUsesTheSelectedSort(
+        TmdbMovieSort sort,
+        string expectedSort)
+    {
+        var handler = new RecordingHandler();
+        var client = CreateClient(handler, TestToken);
+
+        await client.BrowseHorrorMoviesAsync(
+            1,
+            null,
+            0,
+            100,
+            sort,
+            CancellationToken.None);
+
+        var query = Uri.UnescapeDataString(
+            handler.RequestUri?.Query ?? string.Empty);
+
+        Assert.Contains($"sort_by={expectedSort}", query);
+    }
+
+    [Fact]
     public async Task SimilarMoviesUseTheOfficialSimilarEndpoint()
     {
         var handler = new RecordingHandler();

--- a/Catacombs.Tests/TmdbClientTests.cs
+++ b/Catacombs.Tests/TmdbClientTests.cs
@@ -246,6 +246,8 @@ public sealed class TmdbClientTests
             1980,
             6.5,
             250,
+            90,
+            120,
             TmdbMovieSort.HighestRated,
             CancellationToken.None);
 
@@ -262,6 +264,8 @@ public sealed class TmdbClientTests
         Assert.Contains("primary_release_date.lte=1989-12-31", query);
         Assert.Contains("vote_average.gte=6.5", query);
         Assert.Contains("vote_count.gte=250", query);
+        Assert.Contains("with_runtime.gte=90", query);
+        Assert.Contains("with_runtime.lte=120", query);
         Assert.Contains("sort_by=vote_average.desc", query);
     }
 
@@ -282,6 +286,8 @@ public sealed class TmdbClientTests
             null,
             0,
             100,
+            null,
+            null,
             sort,
             CancellationToken.None);
 
@@ -289,6 +295,28 @@ public sealed class TmdbClientTests
             handler.RequestUri?.Query ?? string.Empty);
 
         Assert.Contains($"sort_by={expectedSort}", query);
+    }
+
+    [Fact]
+    public async Task BrowseHorrorCanRemoveTheMinimumVoteRequirement()
+    {
+        var handler = new RecordingHandler();
+        var client = CreateClient(handler, TestToken);
+
+        await client.BrowseHorrorMoviesAsync(
+            1,
+            null,
+            0,
+            0,
+            null,
+            null,
+            TmdbMovieSort.Popular,
+            CancellationToken.None);
+
+        var query = Uri.UnescapeDataString(
+            handler.RequestUri?.Query ?? string.Empty);
+
+        Assert.DoesNotContain("vote_count.gte", query);
     }
 
     [Fact]

--- a/Catacombs/Controllers/TmdbController.cs
+++ b/Catacombs/Controllers/TmdbController.cs
@@ -111,6 +111,8 @@ namespace Catacombs.Controllers
             [FromQuery, Range(1890, 2090)] int? decade = null,
             [FromQuery, Range(0, 10)] double minimumRating = 0,
             [FromQuery, Range(0, 1000000)] int minimumVotes = 100,
+            [FromQuery, Range(1, 600)] int? minimumRuntime = null,
+            [FromQuery, Range(1, 600)] int? maximumRuntime = null,
             [FromQuery] TmdbMovieSort sort = TmdbMovieSort.Popular,
             CancellationToken cancellationToken = default)
         {
@@ -123,12 +125,26 @@ namespace Catacombs.Controllers
                     }));
             }
 
+            if (minimumRuntime.HasValue &&
+                maximumRuntime.HasValue &&
+                minimumRuntime.Value > maximumRuntime.Value)
+            {
+                return Task.FromResult<IActionResult>(
+                    BadRequest(new ProblemDetails
+                    {
+                        Title =
+                            "The minimum runtime cannot exceed the maximum."
+                    }));
+            }
+
             return ProxyAsync(
                 token => _tmdbClient.BrowseHorrorMoviesAsync(
                     page,
                     decade,
                     minimumRating,
                     minimumVotes,
+                    minimumRuntime,
+                    maximumRuntime,
                     sort,
                     token),
                 cancellationToken);

--- a/Catacombs/Controllers/TmdbController.cs
+++ b/Catacombs/Controllers/TmdbController.cs
@@ -105,6 +105,35 @@ namespace Catacombs.Controllers
                 cancellationToken);
         }
 
+        [HttpGet("movies/browse")]
+        public Task<IActionResult> BrowseHorror(
+            [FromQuery, Range(1, 500)] int page = 1,
+            [FromQuery, Range(1890, 2090)] int? decade = null,
+            [FromQuery, Range(0, 10)] double minimumRating = 0,
+            [FromQuery, Range(0, 1000000)] int minimumVotes = 100,
+            [FromQuery] TmdbMovieSort sort = TmdbMovieSort.Popular,
+            CancellationToken cancellationToken = default)
+        {
+            if (decade.HasValue && decade.Value % 10 != 0)
+            {
+                return Task.FromResult<IActionResult>(
+                    BadRequest(new ProblemDetails
+                    {
+                        Title = "The decade must begin with a year ending in 0."
+                    }));
+            }
+
+            return ProxyAsync(
+                token => _tmdbClient.BrowseHorrorMoviesAsync(
+                    page,
+                    decade,
+                    minimumRating,
+                    minimumVotes,
+                    sort,
+                    token),
+                cancellationToken);
+        }
+
         [HttpGet("movies/{movieId:int}/similar")]
         public Task<IActionResult> SimilarMovies(
             [FromRoute, Range(1, int.MaxValue)] int movieId,

--- a/Catacombs/Controllers/TmdbController.cs
+++ b/Catacombs/Controllers/TmdbController.cs
@@ -93,12 +93,14 @@ namespace Catacombs.Controllers
         public Task<IActionResult> Search(
             [FromQuery, Required, StringLength(200)] string query,
             [FromQuery, Range(1, 500)] int page = 1,
+            [FromQuery, Range(1000, 9999)] int? year = null,
             CancellationToken cancellationToken = default)
         {
             return ProxyAsync(
                 token => _tmdbClient.SearchMoviesAsync(
                     query.Trim(),
                     page,
+                    year,
                     token),
                 cancellationToken);
         }

--- a/Catacombs/Services/Tmdb/ITmdbClient.cs
+++ b/Catacombs/Services/Tmdb/ITmdbClient.cs
@@ -21,6 +21,8 @@ namespace Catacombs.Services.Tmdb
             int? decade,
             double minimumRating,
             int minimumVoteCount,
+            int? minimumRuntime,
+            int? maximumRuntime,
             TmdbMovieSort sort,
             CancellationToken cancellationToken);
 

--- a/Catacombs/Services/Tmdb/ITmdbClient.cs
+++ b/Catacombs/Services/Tmdb/ITmdbClient.cs
@@ -16,6 +16,14 @@ namespace Catacombs.Services.Tmdb
             int? primaryReleaseYear,
             CancellationToken cancellationToken);
 
+        Task<TmdbResponse> BrowseHorrorMoviesAsync(
+            int page,
+            int? decade,
+            double minimumRating,
+            int minimumVoteCount,
+            TmdbMovieSort sort,
+            CancellationToken cancellationToken);
+
         Task<TmdbResponse> GetSimilarMoviesAsync(
             int movieId,
             int page,

--- a/Catacombs/Services/Tmdb/ITmdbClient.cs
+++ b/Catacombs/Services/Tmdb/ITmdbClient.cs
@@ -13,6 +13,7 @@ namespace Catacombs.Services.Tmdb
         Task<TmdbResponse> SearchMoviesAsync(
             string query,
             int page,
+            int? primaryReleaseYear,
             CancellationToken cancellationToken);
 
         Task<TmdbResponse> GetSimilarMoviesAsync(

--- a/Catacombs/Services/Tmdb/TmdbClient.cs
+++ b/Catacombs/Services/Tmdb/TmdbClient.cs
@@ -154,6 +154,8 @@ namespace Catacombs.Services.Tmdb
             int? decade,
             double minimumRating,
             int minimumVoteCount,
+            int? minimumRuntime,
+            int? maximumRuntime,
             TmdbMovieSort sort,
             CancellationToken cancellationToken)
         {
@@ -206,6 +208,18 @@ namespace Catacombs.Services.Tmdb
             {
                 query["vote_count.gte"] =
                     FormatNumber(minimumVoteCount);
+            }
+
+            if (minimumRuntime.HasValue)
+            {
+                query["with_runtime.gte"] =
+                    FormatNumber(minimumRuntime.Value);
+            }
+
+            if (maximumRuntime.HasValue)
+            {
+                query["with_runtime.lte"] =
+                    FormatNumber(maximumRuntime.Value);
             }
 
             return GetAsync(

--- a/Catacombs/Services/Tmdb/TmdbClient.cs
+++ b/Catacombs/Services/Tmdb/TmdbClient.cs
@@ -149,6 +149,71 @@ namespace Catacombs.Services.Tmdb
                 cancellationToken);
         }
 
+        public Task<TmdbResponse> BrowseHorrorMoviesAsync(
+            int page,
+            int? decade,
+            double minimumRating,
+            int minimumVoteCount,
+            TmdbMovieSort sort,
+            CancellationToken cancellationToken)
+        {
+            var today = DateOnly.FromDateTime(
+                _timeProvider.GetUtcNow().UtcDateTime);
+            var latestReleaseDate = today;
+            var query = new Dictionary<string, string>
+            {
+                ["language"] = "en-US",
+                ["region"] = "US",
+                ["page"] = FormatNumber(page),
+                ["include_adult"] = "false",
+                ["include_video"] = "false",
+                ["with_genres"] = "27",
+                ["without_genres"] = "10751,10770",
+                ["sort_by"] = sort switch
+                {
+                    TmdbMovieSort.Popular => "popularity.desc",
+                    TmdbMovieSort.HighestRated => "vote_average.desc",
+                    TmdbMovieSort.Newest => "primary_release_date.desc",
+                    TmdbMovieSort.Oldest => "primary_release_date.asc",
+                    _ => throw new ArgumentOutOfRangeException(nameof(sort))
+                }
+            };
+
+            if (decade.HasValue)
+            {
+                var decadeStart = new DateOnly(decade.Value, 1, 1);
+                var decadeEnd = new DateOnly(decade.Value + 9, 12, 31);
+
+                query["primary_release_date.gte"] =
+                    FormatDate(decadeStart);
+
+                if (decadeEnd < latestReleaseDate)
+                {
+                    latestReleaseDate = decadeEnd;
+                }
+            }
+
+            query["primary_release_date.lte"] =
+                FormatDate(latestReleaseDate);
+
+            if (minimumRating > 0)
+            {
+                query["vote_average.gte"] =
+                    FormatDecimal(minimumRating);
+            }
+
+            if (minimumVoteCount > 0)
+            {
+                query["vote_count.gte"] =
+                    FormatNumber(minimumVoteCount);
+            }
+
+            return GetAsync(
+                "discover/movie",
+                query,
+                cancellationToken);
+        }
+
         public Task<TmdbResponse> GetSimilarMoviesAsync(
             int movieId,
             int page,
@@ -246,6 +311,13 @@ namespace Catacombs.Services.Tmdb
         {
             return value.ToString(
                 "yyyy-MM-dd",
+                CultureInfo.InvariantCulture);
+        }
+
+        private static string FormatDecimal(double value)
+        {
+            return value.ToString(
+                "0.#",
                 CultureInfo.InvariantCulture);
         }
     }

--- a/Catacombs/Services/Tmdb/TmdbClient.cs
+++ b/Catacombs/Services/Tmdb/TmdbClient.cs
@@ -125,18 +125,27 @@ namespace Catacombs.Services.Tmdb
         public Task<TmdbResponse> SearchMoviesAsync(
             string query,
             int page,
+            int? primaryReleaseYear,
             CancellationToken cancellationToken)
         {
+            var searchParameters = new Dictionary<string, string>
+            {
+                ["query"] = query,
+                ["include_adult"] = "false",
+                ["language"] = "en-US",
+                ["region"] = "US",
+                ["page"] = FormatNumber(page)
+            };
+
+            if (primaryReleaseYear.HasValue)
+            {
+                searchParameters["primary_release_year"] =
+                    FormatNumber(primaryReleaseYear.Value);
+            }
+
             return GetAsync(
                 "search/movie",
-                new Dictionary<string, string>
-                {
-                    ["query"] = query,
-                    ["include_adult"] = "false",
-                    ["language"] = "en-US",
-                    ["region"] = "US",
-                    ["page"] = FormatNumber(page)
-                },
+                searchParameters,
                 cancellationToken);
         }
 

--- a/Catacombs/Services/Tmdb/TmdbMovieSort.cs
+++ b/Catacombs/Services/Tmdb/TmdbMovieSort.cs
@@ -1,0 +1,10 @@
+namespace Catacombs.Services.Tmdb
+{
+    public enum TmdbMovieSort
+    {
+        Popular,
+        HighestRated,
+        Newest,
+        Oldest
+    }
+}

--- a/Catacombs/client/src/components/ApplicationViews.js
+++ b/Catacombs/client/src/components/ApplicationViews.js
@@ -10,6 +10,7 @@ import { PopularMovieList } from "./Movies/Popular/PopularMovieList";
 import { HiddenGemsList } from "./Movies/HiddenGemsList";
 import { MovieWatchList } from "./Movies/MovieWatchList";
 import { SearchMovies } from "./Movies/SearchMovies";
+import { BrowseHorrorMovies } from "./Movies/BrowseHorrorMovies";
 import { ComingSoonList } from "./Movies/ComingSoonList";
 import { NowPlayingList } from "./Movies/NowPlayingList";
 import { SeenMoviesList } from "./Movies/SeenMoviesList";
@@ -58,6 +59,7 @@ export default function ApplicationViews() {
             <Route path="/movies/hidden-gems/:page" element={<HiddenGemsList />} />
 
             <Route path="/movies/search" element={<SearchMovies />} />
+            <Route path="/movies/browse" element={<BrowseHorrorMovies />} />
             <Route path="/movies/comingsoon" element={<ComingSoonList />} />
             <Route
               path="/movies/comingsoon/:page"

--- a/Catacombs/client/src/components/Header.js
+++ b/Catacombs/client/src/components/Header.js
@@ -87,6 +87,10 @@ export default function Header() {
     "/movies/liked",
     "/movies/disliked"
   ].some(path => location.pathname.startsWith(path));
+  const findMoviesIsActive = [
+    "/movies/search",
+    "/movies/browse"
+  ].some(path => location.pathname.startsWith(path));
 
   const logoutClick = async (event) => {
     event.preventDefault();
@@ -217,6 +221,7 @@ export default function Header() {
                   <NavLink
                     tag={RRNavLink}
                     to="/movies/search"
+                    className={findMoviesIsActive ? "active" : ""}
                     onClick={closeMenu}
                   >
                     <span className="header-nav-label">

--- a/Catacombs/client/src/components/Movies/BrowseHorrorMovies.js
+++ b/Catacombs/client/src/components/Movies/BrowseHorrorMovies.js
@@ -13,7 +13,23 @@ import { MovieSearchModeTabs } from "./MovieSearchModeTabs";
 import "./Movie.css";
 
 const ratingOptions = ["0", "5", "6", "7", "8"];
-const voteOptions = ["50", "100", "250", "500", "1000"];
+const voteOptions = ["0", "50", "100", "250", "500", "1000"];
+const runtimeOptions = ["Any", "Short", "Standard", "Long"];
+const runtimeRanges = {
+    Any: {},
+    Short: { maximumRuntime: "89" },
+    Standard: {
+        minimumRuntime: "90",
+        maximumRuntime: "120"
+    },
+    Long: { minimumRuntime: "121" }
+};
+const runtimeLabels = {
+    Any: "Any length",
+    Short: "Under 90 minutes",
+    Standard: "90 to 120 minutes",
+    Long: "Over 2 hours"
+};
 const sortOptions = [
     "Popular",
     "HighestRated",
@@ -65,6 +81,11 @@ export const BrowseHorrorMovies = () => {
         voteOptions,
         "100"
     );
+    const submittedRuntime = allowedValue(
+        searchParams.get("runtime") || "Any",
+        runtimeOptions,
+        "Any"
+    );
     const submittedSort = allowedValue(
         searchParams.get("sort") || "Popular",
         sortOptions,
@@ -74,6 +95,7 @@ export const BrowseHorrorMovies = () => {
         submittedDecade,
         submittedRating,
         submittedVotes,
+        submittedRuntime,
         submittedSort,
         requestedPage
     ].join(":");
@@ -81,6 +103,7 @@ export const BrowseHorrorMovies = () => {
         decade: submittedDecade,
         rating: submittedRating,
         votes: submittedVotes,
+        runtime: submittedRuntime,
         sort: submittedSort
     });
     const [completedBrowseKey, setCompletedBrowseKey] = useState("");
@@ -101,14 +124,19 @@ export const BrowseHorrorMovies = () => {
             decade: submittedDecade,
             rating: submittedRating,
             votes: submittedVotes,
+            runtime: submittedRuntime,
             sort: submittedSort
         });
         setCompletedBrowseKey("");
+
+        const runtimeRange = runtimeRanges[submittedRuntime];
 
         browseHorrorMovies({
             decade: submittedDecade,
             minimumRating: submittedRating,
             minimumVotes: submittedVotes,
+            minimumRuntime: runtimeRange.minimumRuntime || "",
+            maximumRuntime: runtimeRange.maximumRuntime || "",
             sort: submittedSort
         }, requestedPage).finally(() => {
             if (isActive) {
@@ -126,6 +154,7 @@ export const BrowseHorrorMovies = () => {
         requestedPage,
         submittedDecade,
         submittedRating,
+        submittedRuntime,
         submittedSort,
         submittedVotes
     ]);
@@ -150,6 +179,9 @@ export const BrowseHorrorMovies = () => {
         }
         if (filters.votes !== "100") {
             parameters.votes = filters.votes;
+        }
+        if (filters.runtime !== "Any") {
+            parameters.runtime = filters.runtime;
         }
         if (filters.sort !== "Popular") {
             parameters.sort = filters.sort;
@@ -192,6 +224,9 @@ export const BrowseHorrorMovies = () => {
         }
         if (submittedVotes !== "100") {
             parameters.set("votes", submittedVotes);
+        }
+        if (submittedRuntime !== "Any") {
+            parameters.set("runtime", submittedRuntime);
         }
         if (submittedSort !== "Popular") {
             parameters.set("sort", submittedSort);
@@ -300,6 +335,7 @@ export const BrowseHorrorMovies = () => {
                                     value={filters.votes}
                                     onChange={updateFilter}
                                 >
+                                    <option value="0">Any</option>
                                     <option value="50">50 votes</option>
                                     <option value="100">100 votes</option>
                                     <option value="250">250 votes</option>
@@ -325,6 +361,27 @@ export const BrowseHorrorMovies = () => {
                                     </option>
                                     <option value="Oldest">
                                         Oldest first
+                                    </option>
+                                </select>
+                            </label>
+                            <label>
+                                <span>Runtime</span>
+                                <select
+                                    name="runtime"
+                                    value={filters.runtime}
+                                    onChange={updateFilter}
+                                >
+                                    <option value="Any">
+                                        Any length
+                                    </option>
+                                    <option value="Short">
+                                        Under 90 minutes
+                                    </option>
+                                    <option value="Standard">
+                                        90 to 120 minutes
+                                    </option>
+                                    <option value="Long">
+                                        Over 2 hours
                                     </option>
                                 </select>
                             </label>
@@ -413,7 +470,14 @@ export const BrowseHorrorMovies = () => {
                                         ? "Any rating"
                                         : `${submittedRating}+ rating`}
                                 </span>
-                                <span>{submittedVotes}+ votes</span>
+                                <span>
+                                    {submittedVotes === "0"
+                                        ? "Any number of votes"
+                                        : `${submittedVotes}+ votes`}
+                                </span>
+                                <span>
+                                    {runtimeLabels[submittedRuntime]}
+                                </span>
                                 <span>{sortLabels[submittedSort]}</span>
                             </div>
                         </header>

--- a/Catacombs/client/src/components/Movies/BrowseHorrorMovies.js
+++ b/Catacombs/client/src/components/Movies/BrowseHorrorMovies.js
@@ -1,0 +1,435 @@
+import React, {
+    useContext,
+    useEffect,
+    useRef,
+    useState
+} from "react";
+import { useSearchParams } from "react-router-dom";
+import { Alert, Button, Container, Spinner } from "reactstrap";
+import { MovieContext } from "../Repositories/MovieProvider";
+import { MovieCard } from "./MovieCard";
+import { MoviePagination } from "./MoviePagination";
+import { MovieSearchModeTabs } from "./MovieSearchModeTabs";
+import "./Movie.css";
+
+const ratingOptions = ["0", "5", "6", "7", "8"];
+const voteOptions = ["50", "100", "250", "500", "1000"];
+const sortOptions = [
+    "Popular",
+    "HighestRated",
+    "Newest",
+    "Oldest"
+];
+const sortLabels = {
+    Popular: "Most popular",
+    HighestRated: "Highest rated",
+    Newest: "Newest first",
+    Oldest: "Oldest first"
+};
+const currentDecade =
+    Math.floor(new Date().getFullYear() / 10) * 10;
+const decadeOptions = Array.from(
+    { length: Math.floor((currentDecade - 1890) / 10) + 1 },
+    (_, index) => currentDecade - (index * 10)
+);
+
+const allowedValue = (value, options, fallback) => (
+    options.includes(value) ? value : fallback
+);
+
+export const BrowseHorrorMovies = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+    const parsedPage = Number(searchParams.get("page") || "1");
+    const requestedPage =
+        Number.isInteger(parsedPage) &&
+        parsedPage >= 1 &&
+        parsedPage <= 500
+            ? parsedPage
+            : 1;
+    const decadeParameter = searchParams.get("decade") || "";
+    const parsedDecade = Number(decadeParameter);
+    const submittedDecade =
+        Number.isInteger(parsedDecade) &&
+        parsedDecade >= 1890 &&
+        parsedDecade <= currentDecade &&
+        parsedDecade % 10 === 0
+            ? String(parsedDecade)
+            : "";
+    const submittedRating = allowedValue(
+        searchParams.get("rating") || "0",
+        ratingOptions,
+        "0"
+    );
+    const submittedVotes = allowedValue(
+        searchParams.get("votes") || "100",
+        voteOptions,
+        "100"
+    );
+    const submittedSort = allowedValue(
+        searchParams.get("sort") || "Popular",
+        sortOptions,
+        "Popular"
+    );
+    const browseKey = [
+        submittedDecade,
+        submittedRating,
+        submittedVotes,
+        submittedSort,
+        requestedPage
+    ].join(":");
+    const [filters, setFilters] = useState({
+        decade: submittedDecade,
+        rating: submittedRating,
+        votes: submittedVotes,
+        sort: submittedSort
+    });
+    const [completedBrowseKey, setCompletedBrowseKey] = useState("");
+    const resultsHeadingRef = useRef(null);
+    const previousPageRef = useRef(requestedPage);
+    const {
+        movies,
+        moviePage,
+        browseHorrorMovies,
+        isLoadingMovies,
+        movieLoadError
+    } = useContext(MovieContext);
+
+    useEffect(() => {
+        let isActive = true;
+
+        setFilters({
+            decade: submittedDecade,
+            rating: submittedRating,
+            votes: submittedVotes,
+            sort: submittedSort
+        });
+        setCompletedBrowseKey("");
+
+        browseHorrorMovies({
+            decade: submittedDecade,
+            minimumRating: submittedRating,
+            minimumVotes: submittedVotes,
+            sort: submittedSort
+        }, requestedPage).finally(() => {
+            if (isActive) {
+                setCompletedBrowseKey(browseKey);
+            }
+        });
+
+        return () => {
+            isActive = false;
+        };
+        // browseHorrorMovies comes from MovieProvider.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [
+        browseKey,
+        requestedPage,
+        submittedDecade,
+        submittedRating,
+        submittedSort,
+        submittedVotes
+    ]);
+
+    const updateFilter = (event) => {
+        const { name, value } = event.target;
+        setFilters((currentFilters) => ({
+            ...currentFilters,
+            [name]: value
+        }));
+    };
+
+    const applyFilters = (event) => {
+        event.preventDefault();
+        const parameters = {};
+
+        if (filters.decade) {
+            parameters.decade = filters.decade;
+        }
+        if (filters.rating !== "0") {
+            parameters.rating = filters.rating;
+        }
+        if (filters.votes !== "100") {
+            parameters.votes = filters.votes;
+        }
+        if (filters.sort !== "Popular") {
+            parameters.sort = filters.sort;
+        }
+
+        setSearchParams(parameters);
+    };
+
+    const resetFilters = () => {
+        setSearchParams({});
+    };
+
+    const isCurrentBrowseComplete =
+        completedBrowseKey === browseKey;
+    const hasResults =
+        isCurrentBrowseComplete &&
+        !isLoadingMovies &&
+        !movieLoadError &&
+        movies.length > 0;
+    const noResults =
+        isCurrentBrowseComplete &&
+        !isLoadingMovies &&
+        !movieLoadError &&
+        movies.length === 0;
+    const totalPages = moviePage.totalPages;
+    const currentPage = Math.min(
+        moviePage.page || requestedPage,
+        Math.max(totalPages, 1),
+        500
+    );
+    const resultCount = moviePage.totalResults || movies.length;
+    const pagePath = (page) => {
+        const parameters = new URLSearchParams();
+
+        if (submittedDecade) {
+            parameters.set("decade", submittedDecade);
+        }
+        if (submittedRating !== "0") {
+            parameters.set("rating", submittedRating);
+        }
+        if (submittedVotes !== "100") {
+            parameters.set("votes", submittedVotes);
+        }
+        if (submittedSort !== "Popular") {
+            parameters.set("sort", submittedSort);
+        }
+        if (page > 1) {
+            parameters.set("page", String(page));
+        }
+
+        const query = parameters.toString();
+        return query
+            ? `/movies/browse?${query}`
+            : "/movies/browse";
+    };
+    const pagination = hasResults ? (
+        <MoviePagination
+            getPagePath={pagePath}
+            currentPage={currentPage}
+            totalPages={totalPages}
+        />
+    ) : null;
+
+    useEffect(() => {
+        if (!hasResults) {
+            return;
+        }
+
+        const pageChanged = previousPageRef.current !== requestedPage;
+        previousPageRef.current = requestedPage;
+
+        if (!pageChanged) {
+            return;
+        }
+
+        const reduceMotion = window.matchMedia?.(
+            "(prefers-reduced-motion: reduce)"
+        ).matches;
+
+        resultsHeadingRef.current?.scrollIntoView({
+            behavior: reduceMotion ? "auto" : "smooth",
+            block: "start"
+        });
+    }, [hasResults, requestedPage]);
+
+    return (
+        <>
+            <Container className="search-page">
+                <section
+                    className="movie-search-panel movie-browse-panel"
+                    aria-labelledby="movie-browse-heading"
+                >
+                    <MovieSearchModeTabs />
+                    <p className="movie-search-eyebrow">
+                        Shape your descent
+                    </p>
+                    <h1
+                        id="movie-browse-heading"
+                        className="movie-search-heading"
+                    >
+                        Browse horror
+                    </h1>
+                    <p className="movie-browse-intro">
+                        Explore the archive by era, rating, and popularity
+                        without needing a title in mind.
+                    </p>
+                    <form
+                        className="movie-browse-form"
+                        onSubmit={applyFilters}
+                    >
+                        <div className="movie-browse-filter-grid">
+                            <label>
+                                <span>Release decade</span>
+                                <select
+                                    name="decade"
+                                    value={filters.decade}
+                                    onChange={updateFilter}
+                                >
+                                    <option value="">All decades</option>
+                                    {decadeOptions.map((decade) => (
+                                        <option
+                                            value={decade}
+                                            key={decade}
+                                        >
+                                            {decade}s
+                                        </option>
+                                    ))}
+                                </select>
+                            </label>
+                            <label>
+                                <span>Minimum rating</span>
+                                <select
+                                    name="rating"
+                                    value={filters.rating}
+                                    onChange={updateFilter}
+                                >
+                                    <option value="0">Any rating</option>
+                                    <option value="5">5 or higher</option>
+                                    <option value="6">6 or higher</option>
+                                    <option value="7">7 or higher</option>
+                                    <option value="8">8 or higher</option>
+                                </select>
+                            </label>
+                            <label>
+                                <span>Minimum votes</span>
+                                <select
+                                    name="votes"
+                                    value={filters.votes}
+                                    onChange={updateFilter}
+                                >
+                                    <option value="50">50 votes</option>
+                                    <option value="100">100 votes</option>
+                                    <option value="250">250 votes</option>
+                                    <option value="500">500 votes</option>
+                                    <option value="1000">1,000 votes</option>
+                                </select>
+                            </label>
+                            <label>
+                                <span>Sort results</span>
+                                <select
+                                    name="sort"
+                                    value={filters.sort}
+                                    onChange={updateFilter}
+                                >
+                                    <option value="Popular">
+                                        Most popular
+                                    </option>
+                                    <option value="HighestRated">
+                                        Highest rated
+                                    </option>
+                                    <option value="Newest">
+                                        Newest first
+                                    </option>
+                                    <option value="Oldest">
+                                        Oldest first
+                                    </option>
+                                </select>
+                            </label>
+                        </div>
+                        <div className="movie-browse-actions">
+                            <Button
+                                className="movie-search-button"
+                                type="submit"
+                                disabled={isLoadingMovies}
+                            >
+                                Apply filters
+                            </Button>
+                            <Button
+                                className="movie-search-clear-button"
+                                type="button"
+                                onClick={resetFilters}
+                            >
+                                Reset filters
+                            </Button>
+                        </div>
+                    </form>
+                </section>
+            </Container>
+
+            <Container>
+                {movieLoadError && (
+                    <Alert color="danger" role="alert">
+                        {movieLoadError}
+                    </Alert>
+                )}
+                {isLoadingMovies && (
+                    <div
+                        className="movie-loading"
+                        role="status"
+                        aria-live="polite"
+                    >
+                        <Spinner size="sm" aria-hidden="true" />
+                        <span>Unearthing horror movies...</span>
+                    </div>
+                )}
+                {noResults && (
+                    <section className="movie-empty-state">
+                        <p className="movie-empty-state-eyebrow">
+                            Nothing answers the call
+                        </p>
+                        <h2>No movies match these filters</h2>
+                        <p>
+                            Try widening the decade, rating, or vote
+                            requirements.
+                        </p>
+                        <Button
+                            className="movie-return-action"
+                            type="button"
+                            onClick={resetFilters}
+                        >
+                            Reset filters
+                        </Button>
+                    </section>
+                )}
+                {hasResults && (
+                    <>
+                        <header
+                            className="movie-search-results-heading"
+                            ref={resultsHeadingRef}
+                        >
+                            <p className="movie-search-state-eyebrow">
+                                Horror unearthed
+                            </p>
+                            <h2>Browse results</h2>
+                            <p className="movie-search-result-count">
+                                {resultCount.toLocaleString()}{" "}
+                                {resultCount === 1 ? "title" : "titles"}{" "}
+                                found
+                            </p>
+                            <div
+                                className="movie-browse-summary"
+                                aria-label="Active browse filters"
+                            >
+                                <span>
+                                    {submittedDecade
+                                        ? `${submittedDecade}s`
+                                        : "All decades"}
+                                </span>
+                                <span>
+                                    {submittedRating === "0"
+                                        ? "Any rating"
+                                        : `${submittedRating}+ rating`}
+                                </span>
+                                <span>{submittedVotes}+ votes</span>
+                                <span>{sortLabels[submittedSort]}</span>
+                            </div>
+                        </header>
+                        {pagination}
+                        <div className="discovery-movie-grid">
+                            {movies.map((movie) => (
+                                <MovieCard
+                                    key={movie.id}
+                                    movie={movie}
+                                />
+                            ))}
+                        </div>
+                        {pagination}
+                    </>
+                )}
+            </Container>
+        </>
+    );
+};

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -337,6 +337,41 @@
     box-shadow: 0 1rem 2.5rem rgba(0, 0, 0, 0.26);
 }
 
+.movie-search-mode-tabs {
+    width: fit-content;
+    display: flex;
+    gap: 0.3rem;
+    margin-bottom: 1.4rem;
+    padding: 0.3rem;
+    background-color: #171a1d;
+    border: 1px solid rgba(255, 255, 255, 0.11);
+    border-radius: 0.7rem;
+}
+
+.movie-search-mode-tabs a {
+    padding: 0.48rem 0.8rem;
+    color: #aeb4b9;
+    border-radius: 0.48rem;
+    font-size: 0.8rem;
+    font-weight: 750;
+    text-decoration: none;
+    transition:
+        background-color 150ms ease,
+        color 150ms ease;
+}
+
+.movie-search-mode-tabs a:hover,
+.movie-search-mode-tabs a:focus-visible {
+    color: #ffffff;
+    background-color: rgba(255, 255, 255, 0.06);
+    outline: none;
+}
+
+.movie-search-mode-tabs a.active {
+    color: #ffffff;
+    background-color: #a9163a;
+}
+
 .movie-search-eyebrow {
     margin-bottom: 0.4rem;
     color: #ff718f;
@@ -354,6 +389,88 @@
 .movie-search-form {
     display: grid;
     gap: 0.9rem;
+}
+
+.movie-browse-panel {
+    width: min(100%, 66rem);
+}
+
+.movie-browse-intro {
+    max-width: 46rem;
+    margin: -0.5rem 0 1.4rem;
+    color: #b8bdc2;
+    line-height: 1.6;
+}
+
+.movie-browse-form {
+    display: grid;
+    gap: 1.25rem;
+    padding-top: 1.1rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.movie-browse-filter-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.movie-browse-filter-grid label {
+    min-width: 0;
+    display: grid;
+    gap: 0.45rem;
+    margin: 0;
+}
+
+.movie-browse-filter-grid label > span {
+    color: #d9dcdf;
+    font-size: 0.78rem;
+    font-weight: 750;
+}
+
+.movie-browse-filter-grid select {
+    width: 100%;
+    min-height: 2.8rem;
+    padding: 0.55rem 2rem 0.55rem 0.7rem;
+    color: #f4f5f6;
+    background-color: #171a1d;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 0.6rem;
+}
+
+.movie-browse-filter-grid select:focus {
+    border-color: #ff5579;
+    box-shadow: 0 0 0 0.2rem rgba(230, 30, 77, 0.22);
+    outline: none;
+}
+
+.movie-browse-actions {
+    display: flex;
+    gap: 0.65rem;
+    align-items: center;
+}
+
+.movie-browse-actions .movie-search-clear-button.btn {
+    margin-top: 0;
+    padding: 0.7rem 1rem;
+}
+
+.movie-browse-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+    justify-content: center;
+    margin-top: 0.9rem;
+}
+
+.movie-browse-summary span {
+    padding: 0.35rem 0.6rem;
+    color: #d7dade;
+    background-color: rgba(255, 255, 255, 0.055);
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 999px;
+    font-size: 0.72rem;
+    font-weight: 700;
 }
 
 .movie-search-primary-row {
@@ -548,6 +665,34 @@
 
     .movie-search-year-input {
         width: 100%;
+    }
+
+    .movie-search-mode-tabs {
+        width: 100%;
+    }
+
+    .movie-search-mode-tabs a {
+        flex: 1;
+        text-align: center;
+    }
+
+    .movie-browse-filter-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .movie-browse-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .movie-browse-actions .btn {
+        width: 100%;
+    }
+}
+
+@media (min-width: 576px) and (max-width: 991.98px) {
+    .movie-browse-filter-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 }
 

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -411,7 +411,8 @@
 
 .movie-browse-filter-grid {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns:
+        repeat(auto-fit, minmax(10rem, 1fr));
     gap: 0.85rem;
 }
 
@@ -688,6 +689,34 @@
     .movie-browse-actions .btn {
         width: 100%;
     }
+}
+
+.movie-search-filter-chip.btn {
+    display: inline-flex;
+    gap: 0.45rem;
+    align-items: center;
+    margin-top: 0.8rem;
+    padding: 0.38rem 0.65rem;
+    color: #ffd4dd;
+    background-color: rgba(230, 30, 77, 0.14);
+    border: 1px solid rgba(255, 113, 143, 0.38);
+    border-radius: 999px;
+    font-size: 0.75rem;
+    font-weight: 750;
+}
+
+.movie-search-filter-chip.btn span {
+    color: #ff8ca4;
+    font-size: 1rem;
+    line-height: 0.8;
+}
+
+.movie-search-filter-chip.btn:hover,
+.movie-search-filter-chip.btn:focus-visible {
+    color: #ffffff;
+    background-color: rgba(230, 30, 77, 0.28);
+    border-color: #ff718f;
+    box-shadow: none;
 }
 
 @media (min-width: 576px) and (max-width: 991.98px) {

--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -352,8 +352,62 @@
 }
 
 .movie-search-form {
+    display: grid;
+    gap: 0.9rem;
+}
+
+.movie-search-primary-row {
     display: flex;
     gap: 0.75rem;
+}
+
+.movie-search-filters {
+    display: flex;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.movie-search-filter {
+    display: grid;
+    gap: 0.45rem;
+    margin: 0;
+    color: #d9dcdf;
+    font-size: 0.82rem;
+    font-weight: 750;
+}
+
+.movie-search-filter > span {
+    display: flex;
+    gap: 0.55rem;
+    align-items: baseline;
+}
+
+.movie-search-filter small {
+    color: #92999f;
+    font-size: 0.7rem;
+    font-weight: 650;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+}
+
+.movie-search-year-input {
+    width: 10.5rem;
+    min-height: 2.7rem;
+    padding: 0.55rem 0.75rem;
+    color: #f4f5f6;
+    background-color: #171a1d;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 0.6rem;
+}
+
+.movie-search-year-input:focus {
+    border-color: #ff5579;
+    box-shadow: 0 0 0 0.2rem rgba(230, 30, 77, 0.22);
+    outline: none;
+}
+
+.movie-search-year-input::placeholder {
+    color: #777f86;
 }
 
 .movie-search-input {
@@ -484,11 +538,15 @@
 }
 
 @media (max-width: 575.98px) {
-    .movie-search-form {
+    .movie-search-primary-row {
         flex-direction: column;
     }
 
     .movie-search-button.btn {
+        width: 100%;
+    }
+
+    .movie-search-year-input {
         width: 100%;
     }
 }

--- a/Catacombs/client/src/components/Movies/MovieSearchModeTabs.js
+++ b/Catacombs/client/src/components/Movies/MovieSearchModeTabs.js
@@ -1,0 +1,16 @@
+import React from "react";
+import { NavLink } from "react-router-dom";
+
+export const MovieSearchModeTabs = () => (
+    <nav
+        className="movie-search-mode-tabs"
+        aria-label="Choose how to find movies"
+    >
+        <NavLink to="/movies/search">
+            Search by title
+        </NavLink>
+        <NavLink to="/movies/browse">
+            Browse horror
+        </NavLink>
+    </nav>
+);

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -15,6 +15,15 @@ export const SearchMovies = () => {
     const [searchParams, setSearchParams] = useSearchParams()
     const submittedSearchTerm =
         (searchParams.get("query") || "").trim()
+    const releaseYearParameter =
+        (searchParams.get("year") || "").trim()
+    const parsedReleaseYear = Number(releaseYearParameter)
+    const submittedReleaseYear =
+        Number.isInteger(parsedReleaseYear) &&
+        parsedReleaseYear >= 1000 &&
+        parsedReleaseYear <= 9999
+            ? String(parsedReleaseYear)
+            : ""
     const parsedPage = Number(searchParams.get("page") || "1")
     const requestedPage =
         Number.isInteger(parsedPage) &&
@@ -23,9 +32,12 @@ export const SearchMovies = () => {
             ? parsedPage
             : 1
     const searchKey = submittedSearchTerm
-        ? `${submittedSearchTerm}:${requestedPage}`
+        ? `${submittedSearchTerm}:${submittedReleaseYear}:${requestedPage}`
         : ""
     const [searchTerm, setSearchTerm] = useState(submittedSearchTerm)
+    const [releaseYear, setReleaseYear] = useState(
+        submittedReleaseYear
+    )
     const [completedSearchKey, setCompletedSearchKey] = useState("")
     const resultsHeadingRef = useRef(null)
     const previousPageRef = useRef(requestedPage)
@@ -42,6 +54,7 @@ export const SearchMovies = () => {
         let isActive = true
 
         setSearchTerm(submittedSearchTerm)
+        setReleaseYear(submittedReleaseYear)
         setCompletedSearchKey("")
 
         if (!submittedSearchTerm) {
@@ -51,7 +64,11 @@ export const SearchMovies = () => {
             }
         }
 
-        searchMovies(submittedSearchTerm, requestedPage)
+        searchMovies(
+            submittedSearchTerm,
+            requestedPage,
+            submittedReleaseYear
+        )
             .finally(() => {
                 if (isActive) {
                     setCompletedSearchKey(searchKey)
@@ -67,7 +84,8 @@ export const SearchMovies = () => {
         clearMovieResults,
         requestedPage,
         searchKey,
-        submittedSearchTerm
+        submittedSearchTerm,
+        submittedReleaseYear
     ])
 
     const handleSearch = (event) => {
@@ -77,11 +95,30 @@ export const SearchMovies = () => {
             return
         }
 
-        setSearchParams({ query })
+        const normalizedReleaseYear = releaseYear.trim()
+        const parsedYear = Number(normalizedReleaseYear)
+
+        if (
+            normalizedReleaseYear &&
+            (!Number.isInteger(parsedYear) ||
+                parsedYear < 1000 ||
+                parsedYear > 9999)
+        ) {
+            return
+        }
+
+        const parameters = { query }
+
+        if (normalizedReleaseYear) {
+            parameters.year = normalizedReleaseYear
+        }
+
+        setSearchParams(parameters)
     }
 
     const clearSearch = () => {
         setSearchTerm("")
+        setReleaseYear("")
         setSearchParams({})
     }
 
@@ -111,6 +148,10 @@ export const SearchMovies = () => {
         const parameters = new URLSearchParams({
             query: submittedSearchTerm
         })
+
+        if (submittedReleaseYear) {
+            parameters.set("year", submittedReleaseYear)
+        }
 
         if (page > 1) {
             parameters.set("page", String(page))
@@ -169,35 +210,63 @@ export const SearchMovies = () => {
                             className="movie-search-form"
                             onSubmit={handleSearch}
                         >
-                            <label
-                                className="visually-hidden"
-                                htmlFor="movie-search"
-                            >
-                                Movie title
-                            </label>
-                            <input
-                                className="movie-search-input"
-                                type="search"
-                                id="movie-search"
-                                autoFocus
-                                placeholder="Enter a movie title"
-                                value={searchTerm}
-                                onChange={(event) =>
-                                    setSearchTerm(event.target.value)
-                                }
-                            />
-                            <Button
-                                className="movie-search-button"
-                                type="submit"
-                                disabled={
-                                    isLoadingMovies ||
-                                    !searchTerm.trim()
-                                }
-                            >
-                                {isLoadingMovies
-                                    ? "Searching..."
-                                    : "Search"}
-                            </Button>
+                            <div className="movie-search-primary-row">
+                                <label
+                                    className="visually-hidden"
+                                    htmlFor="movie-search"
+                                >
+                                    Movie title
+                                </label>
+                                <input
+                                    className="movie-search-input"
+                                    type="search"
+                                    id="movie-search"
+                                    autoFocus
+                                    placeholder="Enter a movie title"
+                                    value={searchTerm}
+                                    onChange={(event) =>
+                                        setSearchTerm(event.target.value)
+                                    }
+                                />
+                                <Button
+                                    className="movie-search-button"
+                                    type="submit"
+                                    disabled={
+                                        isLoadingMovies ||
+                                        !searchTerm.trim()
+                                    }
+                                >
+                                    {isLoadingMovies
+                                        ? "Searching..."
+                                        : "Search"}
+                                </Button>
+                            </div>
+                            <div className="movie-search-filters">
+                                <label
+                                    className="movie-search-filter"
+                                    htmlFor="movie-search-year"
+                                >
+                                    <span>
+                                        Release year
+                                        <small>Optional</small>
+                                    </span>
+                                    <input
+                                        className="movie-search-year-input"
+                                        type="number"
+                                        id="movie-search-year"
+                                        min="1000"
+                                        max="9999"
+                                        step="1"
+                                        placeholder="Example: 1979"
+                                        value={releaseYear}
+                                        onChange={(event) =>
+                                            setReleaseYear(
+                                                event.target.value
+                                            )
+                                        }
+                                    />
+                                </label>
+                            </div>
                         </form>
                     </section>
                 </Container>
@@ -237,8 +306,10 @@ export const SearchMovies = () => {
                             </h2>
                             <p>
                                 We couldn&apos;t find a movie matching
-                                &ldquo;{submittedSearchTerm}&rdquo;. Check the
-                                spelling or try another title.
+                                &ldquo;{submittedSearchTerm}&rdquo;
+                                {submittedReleaseYear &&
+                                    ` from ${submittedReleaseYear}`}.
+                                Check the spelling or try another title.
                             </p>
                             <Button
                                 type="button"
@@ -272,6 +343,8 @@ export const SearchMovies = () => {
                                     Results for &ldquo;
                                     {submittedSearchTerm}
                                     &rdquo;
+                                    {submittedReleaseYear &&
+                                        ` from ${submittedReleaseYear}`}
                                 </h2>
                                 <p className="movie-search-result-count">
                                     {resultCount.toLocaleString()}{" "}

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -8,6 +8,7 @@ import { useSearchParams } from "react-router-dom";
 import { MovieContext } from "../Repositories/MovieProvider"
 import { MovieCard } from "./MovieCard";
 import { MoviePagination } from "./MoviePagination";
+import { MovieSearchModeTabs } from "./MovieSearchModeTabs";
 import { Alert, Container, Button, Spinner } from "reactstrap";
 import "./Movie.css"
 
@@ -197,6 +198,7 @@ export const SearchMovies = () => {
                         className="movie-search-panel"
                         aria-labelledby="movie-search-heading"
                     >
+                        <MovieSearchModeTabs />
                         <p className="movie-search-eyebrow">
                             Find your next scare
                         </p>

--- a/Catacombs/client/src/components/Movies/SearchMovies.js
+++ b/Catacombs/client/src/components/Movies/SearchMovies.js
@@ -123,6 +123,11 @@ export const SearchMovies = () => {
         setSearchParams({})
     }
 
+    const clearReleaseYear = () => {
+        setReleaseYear("")
+        setSearchParams({ query: submittedSearchTerm })
+    }
+
     const hasSearched = Boolean(submittedSearchTerm)
     const isCurrentSearchComplete =
         completedSearchKey === searchKey
@@ -353,6 +358,21 @@ export const SearchMovies = () => {
                                     {resultCount === 1 ? "title" : "titles"}{" "}
                                     found
                                 </p>
+                                {submittedReleaseYear && (
+                                    <Button
+                                        type="button"
+                                        className="movie-search-filter-chip"
+                                        aria-label={
+                                            `Remove release year filter ` +
+                                            submittedReleaseYear
+                                        }
+                                        onClick={clearReleaseYear}
+                                    >
+                                        Release year:{" "}
+                                        {submittedReleaseYear}
+                                        <span aria-hidden="true">×</span>
+                                    </Button>
+                                )}
                                 <Button
                                     type="button"
                                     className="movie-search-clear-button"

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -184,6 +184,18 @@ export const MovieProvider = (props) => {
         if (filters.decade) {
             parameters.set("decade", String(filters.decade))
         }
+        if (filters.minimumRuntime) {
+            parameters.set(
+                "minimumRuntime",
+                String(filters.minimumRuntime)
+            )
+        }
+        if (filters.maximumRuntime) {
+            parameters.set(
+                "maximumRuntime",
+                String(filters.maximumRuntime)
+            )
+        }
 
         return loadTmdbMovies(
             `/api/tmdb/movies/browse?${parameters.toString()}`

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -173,6 +173,23 @@ export const MovieProvider = (props) => {
         )
     }
 
+    const browseHorrorMovies = (filters, page = 1) => {
+        const parameters = new URLSearchParams({
+            page: String(page),
+            minimumRating: String(filters.minimumRating),
+            minimumVotes: String(filters.minimumVotes),
+            sort: filters.sort
+        })
+
+        if (filters.decade) {
+            parameters.set("decade", String(filters.decade))
+        }
+
+        return loadTmdbMovies(
+            `/api/tmdb/movies/browse?${parameters.toString()}`
+        )
+    }
+
     const comingSoon = (page = 1) => {
         return loadTmdbMovies(
             `/api/tmdb/movies/upcoming?page=${page}`
@@ -307,6 +324,7 @@ export const MovieProvider = (props) => {
             getWatchlist,
             getAllMovies,
             searchMovies,
+            browseHorrorMovies,
             comingSoon,
             nowPlaying,
             similarMovies,

--- a/Catacombs/client/src/components/Repositories/MovieProvider.js
+++ b/Catacombs/client/src/components/Repositories/MovieProvider.js
@@ -158,10 +158,18 @@ export const MovieProvider = (props) => {
         )
     }
 
-    const searchMovies = (query, page = 1) => {
+    const searchMovies = (query, page = 1, releaseYear = "") => {
+        const parameters = new URLSearchParams({
+            query,
+            page: String(page)
+        })
+
+        if (releaseYear) {
+            parameters.set("year", String(releaseYear))
+        }
+
         return loadTmdbMovies(
-            `/api/tmdb/movies/search?query=${encodeURIComponent(query)}` +
-            `&page=${page}`
+            `/api/tmdb/movies/search?${parameters.toString()}`
         )
     }
 


### PR DESCRIPTION
## Description

This PR improves the movie search and adds a new way to browse horror movies when you don't have a specific title in mind.

## Changes

- Added an optional release-year filter to title searches
- Added a removable release-year badge to search results
- Added a new Browse Horror mode
- Added filters for release decade, minimum rating, minimum votes, and runtime
- Added sorting by popularity, rating, newest, or oldest
- Added an Any option for the minimum vote filter
- Kept filters active during pagination and page refreshes
- Added active-filter summaries and a Reset Filters option
- Limited Browse Horror results to horror movies
- Excluded family movies, TV movies, adult content, and future releases
- Added loading, error, and empty-result states
- Updated the navigation to recognize both search modes

## Testing

- The frontend builds successfully
- All 31 backend tests pass
- Title search works with and without a release year
- Release-year filtering continues to work during pagination
- The release-year badge removes the active year correctly
- Browse Horror filters and sorting return the expected results
- Browse Horror pagination keeps the selected filters
- Reset Filters returns Browse Horror to its default settings