### PR TITLE
Add filters and sorting to My Movies lists

### DIFF
--- a/Catacombs/client/src/components/Movies/Movie.css
+++ b/Catacombs/client/src/components/Movies/Movie.css
@@ -34,6 +34,68 @@
     text-transform: uppercase;
 }
 
+.movie-collection-tools {
+    display: grid;
+    gap: 0.85rem;
+    margin: 1.75rem 0 1.25rem;
+    padding: 1rem;
+    border: 1px solid rgba(255, 255, 255, 0.1);
+    border-radius: 0.9rem;
+    background-color: rgba(17, 19, 22, 0.72);
+}
+
+.movie-collection-tool-fields {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(12rem, 18rem);
+    gap: 0.85rem;
+}
+
+.movie-collection-tool {
+    min-width: 0;
+    display: grid;
+    gap: 0.4rem;
+    margin: 0;
+}
+
+.movie-collection-tool > span {
+    color: #d9dcdf;
+    font-size: 0.78rem;
+    font-weight: 750;
+}
+
+.movie-collection-tool input,
+.movie-collection-tool select {
+    width: 100%;
+    min-height: 2.85rem;
+    padding: 0.55rem 0.75rem;
+    color: #f4f5f6;
+    background-color: #171a1d;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 0.6rem;
+}
+
+.movie-collection-tool select {
+    padding-right: 2rem;
+}
+
+.movie-collection-tool input:focus,
+.movie-collection-tool select:focus {
+    border-color: #ff5579;
+    box-shadow: 0 0 0 0.2rem rgba(230, 30, 77, 0.22);
+    outline: none;
+}
+
+.movie-collection-tool input::placeholder {
+    color: #777f86;
+}
+
+.movie-collection-result-count {
+    margin: 0;
+    color: #92999f;
+    font-size: 0.78rem;
+    font-weight: 650;
+}
+
 .similar-movies-header {
     padding-top: 1rem;
 }
@@ -656,6 +718,10 @@
 }
 
 @media (max-width: 575.98px) {
+    .movie-collection-tool-fields {
+        grid-template-columns: 1fr;
+    }
+
     .movie-search-primary-row {
         flex-direction: column;
     }

--- a/Catacombs/client/src/components/Movies/MovieCollectionPage.js
+++ b/Catacombs/client/src/components/Movies/MovieCollectionPage.js
@@ -1,9 +1,72 @@
-import React, { useContext, useEffect, useState } from "react";
+import React, {
+    useContext,
+    useEffect,
+    useMemo,
+    useState
+} from "react";
 import { Link } from "react-router-dom";
 import { Button, Container, Spinner } from "reactstrap";
 import { MovieContext } from "../Repositories/MovieProvider";
 import { MovieCollectionHeading } from "./MovieCollectionHeading";
 import "./Movie.css";
+
+const compareTitles = (firstMovie, secondMovie) => (
+    (firstMovie.title || "").localeCompare(
+        secondMovie.title || "",
+        undefined,
+        { sensitivity: "base" }
+    )
+);
+
+const getReleaseTimestamp = (movie) => {
+    const timestamp = Date.parse(movie.release_date);
+
+    if (!Number.isFinite(timestamp)) {
+        return null;
+    }
+
+    const releaseDate = new Date(timestamp);
+    return releaseDate.getUTCFullYear() > 1 ? timestamp : null;
+};
+
+const compareReleaseDates = (firstMovie, secondMovie, direction) => {
+    const firstRelease = getReleaseTimestamp(firstMovie);
+    const secondRelease = getReleaseTimestamp(secondMovie);
+
+    if (firstRelease === null && secondRelease === null) {
+        return compareTitles(firstMovie, secondMovie);
+    }
+    if (firstRelease === null) {
+        return 1;
+    }
+    if (secondRelease === null) {
+        return -1;
+    }
+
+    return ((firstRelease - secondRelease) * direction) ||
+        compareTitles(firstMovie, secondMovie);
+};
+
+const sortMovies = (movies, sortOrder) => (
+    [...movies].sort((firstMovie, secondMovie) => {
+        switch (sortOrder) {
+            case "newest":
+                return compareReleaseDates(firstMovie, secondMovie, -1);
+            case "oldest":
+                return compareReleaseDates(firstMovie, secondMovie, 1);
+            case "rating": {
+                const ratingDifference =
+                    Number(secondMovie.vote_average || 0) -
+                    Number(firstMovie.vote_average || 0);
+
+                return ratingDifference ||
+                    compareTitles(firstMovie, secondMovie);
+            }
+            default:
+                return compareTitles(firstMovie, secondMovie);
+        }
+    })
+);
 
 export const MovieCollectionPage = ({
     loadMovies,
@@ -22,6 +85,20 @@ export const MovieCollectionPage = ({
     const [reload, setReload] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [loadError, setLoadError] = useState(false);
+    const [titleFilter, setTitleFilter] = useState("");
+    const [sortOrder, setSortOrder] = useState("title");
+
+    const visibleMovies = useMemo(() => {
+        const normalizedFilter = titleFilter.trim().toLocaleLowerCase();
+        const filteredMovies = normalizedFilter
+            ? movies.filter((movie) =>
+                (movie.title || "")
+                    .toLocaleLowerCase()
+                    .includes(normalizedFilter))
+            : movies;
+
+        return sortMovies(filteredMovies, sortOrder);
+    }, [movies, sortOrder, titleFilter]);
 
     useEffect(() => {
         let isActive = true;
@@ -99,15 +176,81 @@ export const MovieCollectionPage = ({
                     </Link>
                 </section>
             ) : (
-                <div className="discovery-movie-grid">
-                    {movies.map((movie) => (
-                        <CardComponent
-                            key={movie.id}
-                            movie={movie}
-                            reloadProp={setReload}
-                        />
-                    ))}
-                </div>
+                <>
+                    <section
+                        className="movie-collection-tools"
+                        aria-label={`Filter and sort ${title}`}
+                    >
+                        <div className="movie-collection-tool-fields">
+                            <label className="movie-collection-tool">
+                                <span>Find in this list</span>
+                                <input
+                                    type="search"
+                                    value={titleFilter}
+                                    placeholder="Filter by movie title"
+                                    onChange={(event) =>
+                                        setTitleFilter(event.target.value)}
+                                />
+                            </label>
+                            <label className="movie-collection-tool">
+                                <span>Sort movies</span>
+                                <select
+                                    value={sortOrder}
+                                    onChange={(event) =>
+                                        setSortOrder(event.target.value)}
+                                >
+                                    <option value="title">Title A–Z</option>
+                                    <option value="newest">
+                                        Newest release
+                                    </option>
+                                    <option value="oldest">
+                                        Oldest release
+                                    </option>
+                                    <option value="rating">
+                                        Highest TMDB rating
+                                    </option>
+                                </select>
+                            </label>
+                        </div>
+                        <p
+                            className="movie-collection-result-count"
+                            aria-live="polite"
+                        >
+                            Showing {visibleMovies.length} of {movies.length}{" "}
+                            {movies.length === 1 ? "movie" : "movies"}
+                        </p>
+                    </section>
+
+                    {visibleMovies.length === 0 ? (
+                        <section className="movie-empty-state">
+                            <p className="movie-empty-state-eyebrow">
+                                Nothing answers the search
+                            </p>
+                            <h2>No matching movies</h2>
+                            <p>
+                                Nothing in this collection matches
+                                &ldquo;{titleFilter.trim()}&rdquo;.
+                            </p>
+                            <Button
+                                type="button"
+                                className="movie-return-action"
+                                onClick={() => setTitleFilter("")}
+                            >
+                                Clear filter
+                            </Button>
+                        </section>
+                    ) : (
+                        <div className="discovery-movie-grid">
+                            {visibleMovies.map((movie) => (
+                                <CardComponent
+                                    key={movie.id}
+                                    movie={movie}
+                                    reloadProp={setReload}
+                                />
+                            ))}
+                        </div>
+                    )}
+                </>
             )}
         </Container>
     );

--- a/Catacombs/client/src/components/Movies/MovieCollectionPage.js
+++ b/Catacombs/client/src/components/Movies/MovieCollectionPage.js
@@ -4,11 +4,18 @@ import React, {
     useMemo,
     useState
 } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import { Button, Container, Spinner } from "reactstrap";
 import { MovieContext } from "../Repositories/MovieProvider";
 import { MovieCollectionHeading } from "./MovieCollectionHeading";
 import "./Movie.css";
+
+const validSortOrders = new Set([
+    "title",
+    "newest",
+    "oldest",
+    "rating"
+]);
 
 const compareTitles = (firstMovie, secondMovie) => (
     (firstMovie.title || "").localeCompare(
@@ -82,11 +89,28 @@ export const MovieCollectionPage = ({
     emptyActionPath
 }) => {
     const { movies } = useContext(MovieContext);
+    const [searchParams, setSearchParams] = useSearchParams();
     const [reload, setReload] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const [loadError, setLoadError] = useState(false);
-    const [titleFilter, setTitleFilter] = useState("");
-    const [sortOrder, setSortOrder] = useState("title");
+    const titleFilter = searchParams.get("filter") || "";
+    const requestedSortOrder = searchParams.get("sort") || "title";
+    const sortOrder = validSortOrders.has(requestedSortOrder)
+        ? requestedSortOrder
+        : "title";
+
+    const updateCollectionView = (nextFilter, nextSortOrder) => {
+        const parameters = new URLSearchParams();
+
+        if (nextFilter.trim()) {
+            parameters.set("filter", nextFilter);
+        }
+        if (nextSortOrder !== "title") {
+            parameters.set("sort", nextSortOrder);
+        }
+
+        setSearchParams(parameters, { replace: true });
+    };
 
     const visibleMovies = useMemo(() => {
         const normalizedFilter = titleFilter.trim().toLocaleLowerCase();
@@ -189,7 +213,10 @@ export const MovieCollectionPage = ({
                                     value={titleFilter}
                                     placeholder="Filter by movie title"
                                     onChange={(event) =>
-                                        setTitleFilter(event.target.value)}
+                                        updateCollectionView(
+                                            event.target.value,
+                                            sortOrder
+                                        )}
                                 />
                             </label>
                             <label className="movie-collection-tool">
@@ -197,7 +224,10 @@ export const MovieCollectionPage = ({
                                 <select
                                     value={sortOrder}
                                     onChange={(event) =>
-                                        setSortOrder(event.target.value)}
+                                        updateCollectionView(
+                                            titleFilter,
+                                            event.target.value
+                                        )}
                                 >
                                     <option value="title">Title A–Z</option>
                                     <option value="newest">
@@ -234,7 +264,8 @@ export const MovieCollectionPage = ({
                             <Button
                                 type="button"
                                 className="movie-return-action"
-                                onClick={() => setTitleFilter("")}
+                                onClick={() =>
+                                    updateCollectionView("", sortOrder)}
                             >
                                 Clear filter
                             </Button>


### PR DESCRIPTION
## Description

This PR makes the My Movies lists easier to search and organize. It adds shared filtering and sorting controls while keeping the current collection design.

## Changes

- Added title filtering to all My Movies lists
- Added sorting by title, release date, and TMDB rating
- Added a count showing how many movies are currently displayed
- Added a styled message when no movies match the filter
- Preserved filters and sorting when returning from movie details
- Added responsive styling for smaller screens

## Testing

- The frontend production build completes successfully
- Filtering works on each My Movies list
- All sorting options work correctly
- Clearing the filter restores the full collection
- Filters and sorting remain selected after returning from movie details